### PR TITLE
COOK-1175 - Add Mac OS X support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ Platform
 
 * Debian, Ubuntu
 * CentOS, Red Hat, Fedora
+* Mac OS X (Using homebrew)
 
 Tested on:
 
 * Debian 5.0
 * Ubuntu 10.04
 * CentOS 5.5
+* Mac OS X 10.7.2
 
 Cookbooks
 ---------
@@ -24,6 +26,8 @@ Cookbooks
 Requires Opscode's openssl cookbook for secure password generation. See _Attributes_ and _Usage_ for more information.
 
 Requires a C compiler and Ruby development package in order to build mysql gem with native extensions. On Debian and Ubuntu systems this is satisfied by installing the "build-essential" and "ruby-dev" packages before running Chef. See USAGE below for information on how to handle this during a Chef run.
+
+Requires homebrew cookbook on Mac OS X.
 
 Resources and Providers
 =======================

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -67,6 +67,13 @@ when "windows"
   default['mysql']['conf_dir']                = "#{mysql['basedir']}"
   default['mysql']['old_passwords']           = 0
   default['mysql']['grants_path']             = "#{mysql['conf_dir']}\\grants.sql"
+when "mac_os_x"
+  default['mysql']['package_name']            = "mysql"
+  default['mysql']['basedir']                 = "/usr/local/Cellar"
+  default['mysql']['data_dir']                = "/usr/local/var/mysql"
+  default['mysql']['root_group']              = "admin"
+  default['mysql']['mysqladmin_bin']          = "/usr/local/bin/mysqladmin"
+  default['mysql']['mysql_bin']               = "/usr/local/bin/mysql"
 else
   default['mysql']['package_name']            = "mysql-server"
   default['mysql']['service_name']            = "mysql"

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ recipe            "mysql::client", "Installs packages required for mysql clients
 recipe            "mysql::server", "Installs packages required for mysql servers w/o manual intervention"
 recipe            "mysql::server_ec2", "Performs EC2-specific mountpoint manipulation"
 
-%w{ debian ubuntu centos suse fedora redhat scientific amazon freebsd windows }.each do |os|
+%w{ debian ubuntu centos suse fedora redhat scientific amazon freebsd windows mac_os_x }.each do |os|
   supports os
 end
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -49,6 +49,9 @@ when "windows"
     windows_package(*args, &blk)
   end
   [node['mysql']['client']['package_name']]
+when "mac_os_x"
+  include_recipe 'homebrew'
+  %w{mysql-connector-c}
 else
   %w{mysql-client libmysqlclient-dev}
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -78,53 +78,56 @@ package node['mysql']['package_name'] do
   action :install
 end
 
-directory node['mysql']['confd_dir'] do
-  owner "mysql" unless platform? 'windows'
-  group "mysql" unless platform? 'windows'
-  action :create
-  recursive true
-end
+unless platform?(%w{mac_os_x})
 
-if platform? 'windows'
-  require 'win32/service'
-
-  windows_path node['mysql']['bin_dir'] do
-    action :add
+  directory node['mysql']['confd_dir'] do
+    owner "mysql" unless platform? 'windows'
+    group "mysql" unless platform? 'windows'
+    action :create
+    recursive true
   end
 
-  windows_batch "install mysql service" do
-    command "\"#{node['mysql']['bin_dir']}\\mysqld.exe\" --install #{node['mysql']['service_name']}"
-    not_if { Win32::Service.exists?(node['mysql']['service_name']) }
+  if platform? 'windows'
+    require 'win32/service'
+
+    windows_path node['mysql']['bin_dir'] do
+      action :add
+    end
+
+    windows_batch "install mysql service" do
+      command "\"#{node['mysql']['bin_dir']}\\mysqld.exe\" --install #{node['mysql']['service_name']}"
+      not_if { Win32::Service.exists?(node['mysql']['service_name']) }
+    end
   end
-end
 
-service "mysql" do
-  service_name node['mysql']['service_name']
-  if node['mysql']['use_upstart']
-    restart_command "restart mysql"
-    stop_command "stop mysql"
-    start_command "start mysql"
+  service "mysql" do
+    service_name node['mysql']['service_name']
+    if node['mysql']['use_upstart']
+      restart_command "restart mysql"
+      stop_command "stop mysql"
+      start_command "start mysql"
+    end
+    supports :status => true, :restart => true, :reload => true
+    action :nothing
   end
-  supports :status => true, :restart => true, :reload => true
-  action :nothing
-end
 
-skip_federated = case node['platform']
-                 when 'fedora', 'ubuntu', 'amazon'
-                   true
-                 when 'centos', 'redhat', 'scientific'
-                   node['platform_version'].to_f < 6.0
-                 else
-                   false
-                 end
+  skip_federated = case node['platform']
+                   when 'fedora', 'ubuntu', 'amazon'
+                     true
+                   when 'centos', 'redhat', 'scientific'
+                     node['platform_version'].to_f < 6.0
+                   else
+                     false
+                   end
 
-template "#{node['mysql']['conf_dir']}/my.cnf" do
-  source "my.cnf.erb"
-  owner "root" unless platform? 'windows'
-  group node['mysql']['root_group'] unless platform? 'windows'
-  mode "0644"
-  notifies :restart, resources(:service => "mysql"), :immediately
-  variables :skip_federated => skip_federated
+  template "#{node['mysql']['conf_dir']}/my.cnf" do
+    source "my.cnf.erb"
+    owner "root" unless platform? 'windows'
+    group node['mysql']['root_group'] unless platform? 'windows'
+    mode "0644"
+    notifies :restart, resources(:service => "mysql"), :immediately
+    variables :skip_federated => skip_federated
+  end
 end
 
 unless Chef::Config[:solo]
@@ -148,31 +151,42 @@ unless platform?(%w{debian ubuntu})
 
 end
 
-grants_path = node['mysql']['grants_path']
+# Homebrew has its own way to do databases
+if platform?(%w{mac_os_x})
 
-begin
-  t = resources("template[#{grants_path}]")
-rescue
-  Chef::Log.info("Could not find previously defined grants.sql resource")
-  t = template grants_path do
-    source "grants.sql.erb"
-    owner "root" unless platform? 'windows'
-    group node['mysql']['root_group'] unless platform? 'windows'
-    mode "0600"
-    action :create
+  execute "mysql-install-db" do
+    command "mysql_install_db --verbose --user=`whoami` --basedir=\"$(brew --prefix mysql)\" --datadir=#{node['mysql']['data_dir']} --tmpdir=/tmp"
+    environment('TMPDIR' => nil)
+    action :run
+    creates "#{node['mysql']['data_dir']}/mysql"
   end
-end
 
-if platform? 'windows'
-  windows_batch "mysql-install-privileges" do
-    command "\"#{node['mysql']['mysql_bin']}\" -u root #{node['mysql']['server_root_password'].empty? ? '' : '-p' }\"#{node['mysql']['server_root_password']}\" < \"#{grants_path}\""
-    action :nothing
-    subscribes :run, resources("template[#{grants_path}]"), :immediately
-  end
 else
-  execute "mysql-install-privileges" do
-    command "\"#{node['mysql']['mysql_bin']}\" -u root #{node['mysql']['server_root_password'].empty? ? '' : '-p' }\"#{node['mysql']['server_root_password']}\" < \"#{grants_path}\""
-    action :nothing
-    subscribes :run, resources("template[#{grants_path}]"), :immediately
+  grants_path = node['mysql']['grants_path']
+  begin
+    t = resources("template[#{grants_path}]")
+  rescue
+    Chef::Log.info("Could not find previously defined grants.sql resource")
+    t = template grants_path do
+      source "grants.sql.erb"
+      owner "root" unless platform? 'windows'
+      group node['mysql']['root_group'] unless platform? 'windows'
+      mode "0600"
+      action :create
+    end
+  end
+
+  if platform? 'windows'
+    windows_batch "mysql-install-privileges" do
+      command "\"#{node['mysql']['mysql_bin']}\" -u root #{node['mysql']['server_root_password'].empty? ? '' : '-p' }\"#{node['mysql']['server_root_password']}\" < \"#{grants_path}\""
+      action :nothing
+      subscribes :run, resources("template[#{grants_path}]"), :immediately
+    end
+  else
+    execute "mysql-install-privileges" do
+      command "\"#{node['mysql']['mysql_bin']}\" -u root #{node['mysql']['server_root_password'].empty? ? '' : '-p' }\"#{node['mysql']['server_root_password']}\" < \"#{grants_path}\""
+      action :nothing
+      subscribes :run, resources("template[#{grants_path}]"), :immediately
+    end
   end
 end


### PR DESCRIPTION
Uses the homebrew cookbook. Currently does not start MySQL for you, or
set the root password, since this is most likely a development client
running under solo.
