### PR TITLE
[COOK-1151] Fixed mysql::server_ec2 recipe not enabling the bound /var/l...

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ License and Author
 Author:: Joshua Timberman (<joshua@opscode.com>)
 Author:: AJ Christensen (<aj@opscode.com>)
 Author:: Seth Chisamore (<schisamo@opscode.com>)
+Author:: Brian Bianco (<brian.bianco@gmail.com>)
 
 Copyright:: 2009-2011 Opscode, Inc
 

--- a/recipes/server_ec2.rb
+++ b/recipes/server_ec2.rb
@@ -40,7 +40,7 @@ if (node.attribute?('ec2') && ! FileTest.directory?(node['mysql']['ec2_path']))
     device node['mysql']['ec2_path']
     fstype "none"
     options "bind,rw"
-    action :mount
+    action [:mount, :enable]
   end
 
   service "mysql" do


### PR DESCRIPTION
Changed the action for the server_ec2 recipe as on reboot the mount point would no longer be bound, causing mysql startup to fail.

Related ticket is 
http://tickets.opscode.com/browse/COOK-1151
