### PR TITLE
Fixed universal windows cookbook dep in metadata.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,11 +13,8 @@ recipe            "mysql::server_ec2", "Performs EC2-specific mountpoint manipul
   supports os
 end
 
-depends "openssl"
-
-case node['platform'] == "windows"
-  depends "windows"
-end
+depends  "openssl"
+suggests "windows"
 
 attribute "mysql/server_root_password",
   :display_name => "MySQL Server Root Password",


### PR DESCRIPTION
current metadata seems to break at least lucid64 VM's, and presumeably any non-windows
