### PR TITLE
special mysql service commands not needed on lucid

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -100,7 +100,7 @@ end
 
 service "mysql" do
   service_name node['mysql']['service_name']
-  if (platform?("ubuntu") && node.platform_version.to_f >= 10.04)
+  if (platform?("ubuntu") && node.platform_version.to_f > 10.04)
     restart_command "restart mysql"
     stop_command "stop mysql"
     start_command "start mysql"


### PR DESCRIPTION
Doesn't appear to cause ill-effect with standard mysql-server, but messes with trying to use percona-server-server with the mysql cookbook (see pull request [COOK-1236](http://tickets.opscode.com/browse/COOK-1236)).
