### PR TITLE
COOK-1113 Adding attribute to determine if upstart scripts should be used

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -87,6 +87,8 @@ if attribute?('ec2')
   default['mysql']['ebs_vol_size'] = 50
 end
 
+default['mysql']['use_upstart'] = platform?("ubuntu") && node.platform_version.to_f >= 10.04
+
 default['mysql']['allow_remote_root']               = false
 default['mysql']['tunable']['back_log']             = "128"
 default['mysql']['tunable']['key_buffer']           = "256M"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -100,7 +100,7 @@ end
 
 service "mysql" do
   service_name node['mysql']['service_name']
-  if (platform?("ubuntu") && node.platform_version.to_f >= 10.04)
+  if node['mysql']['use_upstart']
     restart_command "restart mysql"
     stop_command "stop mysql"
     start_command "start mysql"


### PR DESCRIPTION
Defaulting to existing logic (true for ubuntu >= 10.04).  I think this is the best way to allow for the flexibility to control whether upstart is used (some mysql drop in replacements do not have upstart scripts - such as percona) while still maintaining backwards compatibility.

http://tickets.opscode.com/browse/COOK-1113
