### PR TITLE
Add a tunable to create a network ACL when allowing remote_root_access

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Attributes
 * `mysql['data_dir']` - Location for mysql data directory, default is "/var/lib/mysql"
 * `mysql['conf_dir']` - Location for mysql conf directory, default is "/etc/mysql"
 * `mysql['ec2_path']` - location of mysql data_dir on EC2 nodes, default "/mnt/mysql"
+* `mysql['root_network_acl']` - Set define the network the root user will be able to login from, default is the bind_address
 
 Performance tuning attributes, each corresponds to the same-named parameter in my.cnf; default values listed
 

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -93,6 +93,7 @@ end
 default['mysql']['use_upstart'] = platform?("ubuntu") && node.platform_version.to_f >= 10.04
 
 default['mysql']['allow_remote_root']               = false
+default['mysql']['root_network_acl']                = default['mysql']['bind_address']
 default['mysql']['tunable']['back_log']             = "128"
 default['mysql']['tunable']['key_buffer']           = "256M"
 default['mysql']['tunable']['max_allowed_packet']   = "16M"

--- a/templates/default/grants.sql.erb
+++ b/templates/default/grants.sql.erb
@@ -13,3 +13,4 @@ GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%' identified by '<%= node['mysql']['s
 GRANT ALL ON *.* TO 'root'@'%' IDENTIFIED BY '<%= node['mysql']['server_root_password'] %>' WITH GRANT OPTION;
 <% end -%>
 SET PASSWORD FOR 'root'@'localhost' = PASSWORD('<%= node['mysql']['server_root_password'] %>');
+SET PASSWORD FOR 'root'@'<%= node['mysql']['root_network_acl'] %>' = PASSWORD('<%= node['mysql']['server_root_password'] %>');


### PR DESCRIPTION
This pull request adds a tunable (root_network_acl) to permit root access the network.  Currently this toggle only allows remote root access from localhost.  This extends it so that you can set root_network_acl to an ipaddress/netmask such as 192.168.1.0/255.255.255.0 and the grants.sql file is updated accordingly.
