### PR TITLE
Mysql server attributes file using methods from recipe dsl in a breaks-things-sometimes way

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -97,7 +97,7 @@ if attribute?('ec2')
   default['mysql']['ebs_vol_size'] = 50
 end
 
-default['mysql']['use_upstart'] = platform?("ubuntu") && node.platform_version.to_f >= 10.04
+default['mysql']['use_upstart'] = (node.platform == "ubuntu" && node.platform_version.to_f >= 10.04)
 
 default['mysql']['allow_remote_root']               = false
 default['mysql']['tunable']['back_log']             = "128"


### PR DESCRIPTION
The `attributes/server.rb` file is using the `#platform?` method - which is part of the Recipe DSL and is not defined when the attributes file is being parsed.

I found this on Mac OS X 10.7, where the line that is changed evaluates to `true`. This is obviously an error, since OS X doesn't have upstart. However, for most use cases, this is fine, since 
1. upstart is not uncommon in linux land and
2. this attribute is only used in ways that normally don't cause problems. When the service to be started is called "mysql", as is the most common convention, there is no net effect - but when using MacPorts, the service is called "mysql5-server", and therefore fails.

What is happening then is that `#method_missing` is being called at `lib/chef/node/attribute.rb` and it is _setting_ an attribute _named_ `platform?` and returning the passed in value.

The net effect is that what is intended is: `platform?("ubuntu") == false` and what happens is `platform?("ubuntu") == "ubuntu"`. When the rest of the line is evaluated, and the version (for os x) is indeed high enough, we get a false positive.

The change is simply to check node[:platform] instead, perhaps in future fixing `#method_missing` in `attribute.rb` to not be so gratuitively permissive, as it has massive silent-shoot-in-the-foot potential.
