### PR TITLE
mysql-server-5.5 refuses to start with default attributes due to "innodb_flush_method"

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -136,7 +136,7 @@ default['mysql']['tunable']['innodb_buffer_pool_size']         = "128M"
 default['mysql']['tunable']['innodb_additional_mem_pool_size'] = "8M"
 default['mysql']['tunable']['innodb_data_file_path']           = "ibdata1:10M:autoextend"
 default['mysql']['tunable']['innodb_flush_log_at_trx_commit']  = "1"
-default['mysql']['tunable']['innodb_flush_method']             = ""
+default['mysql']['tunable']['innodb_flush_method']             = nil
 default['mysql']['tunable']['innodb_log_buffer_size']          = "8M"
 default['mysql']['tunable']['innodb_adaptive_flushing']        = "true"
 

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -141,9 +141,9 @@ innodb_data_file_path   = <%= node['mysql']['tunable']['innodb_data_file_path'] 
 innodb_file_per_table
 innodb_flush_log_at_trx_commit = <%= node['mysql']['tunable']['innodb_flush_log_at_trx_commit'] %>
 
-<% if node['mysql']['tunable']['innodb_flush_method'] != "" %>
+<%- if node['mysql']['tunable']['innodb_flush_method'] %>
   innodb_flush_method     = <%= node['mysql']['tunable']['innodb_flush_method'] %>
-<% end %>
+<%- end %>
 innodb_log_buffer_size  = <%= node['mysql']['tunable']['innodb_log_buffer_size'] %>
 innodb_adaptive_flushing  = <%= node['mysql']['tunable']['innodb_adaptive_flushing'] %>
 


### PR DESCRIPTION
I've removed the default value of `innodb_flush_method` to prevent the crash.

Tested on Ubuntu 12.04.

---

MySQL log:

```
120616 13:26:15 [Warning] The syntax '--log-slow-queries' is deprecated and will be removed in a future release. Please use '--slow-query-log'/'--slow-query-log-file' instead.
120616 13:26:15 [Note] Plugin 'FEDERATED' is disabled.
120616 13:26:15 InnoDB: The InnoDB memory heap is disabled
120616 13:26:15 InnoDB: Mutexes and rw_locks use GCC atomic builtins
120616 13:26:15 InnoDB: Compressed tables use zlib 1.2.3.4
120616 13:26:15 InnoDB: Unrecognized value fdatasync for innodb_flush_method
120616 13:26:15 [ERROR] Plugin 'InnoDB' init function returned error.
120616 13:26:15 [ERROR] Plugin 'InnoDB' registration as a STORAGE ENGINE failed.
120616 13:26:15 [ERROR] Unknown/unsupported storage engine: InnoDB
120616 13:26:15 [ERROR] Aborting
```

Chef log:

```
[2012-06-16T13:25:32-04:00] INFO: Processing service[mysql] action restart (mysql::server line 103)
[2012-06-16T13:25:37-04:00] ERROR: service[mysql] (mysql::server line 103) has had an error
[2012-06-16T13:25:37-04:00] ERROR: template[/etc/mysql/my.cnf] (/tmp/Wed20Jun2012220823EDT/cookbooks/mysql/recipes/server.rb:123:in `from_file') had an error:
service[mysql] (mysql::server line 103) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
---- Begin output of restart mysql ----
STDOUT: 
STDERR: restart: Job failed to restart
---- End output of restart mysql ----
Ran restart mysql returned 1
/usr/local/lib/ruby/gems/1.9.1/gems/mixlib-shellout-1.0.0.rc.1/lib/mixlib/shellout.rb:242:in `invalid!'
/usr/local/lib/ruby/gems/1.9.1/gems/mixlib-shellout-1.0.0.rc.1/lib/mixlib/shellout.rb:228:in `error!'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/mixin/shell_out.rb:36:in `shell_out!'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/provider/service/simple.rb:57:in `restart_service'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/provider/service/init.rb:54:in `restart_service'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/provider/service.rb:78:in `action_restart'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/resource.rb:454:in `run_action'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/runner.rb:49:in `run_action'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/runner.rb:57:in `block in run_action'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/runner.rb:55:in `each'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/runner.rb:55:in `run_action'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/runner.rb:85:in `block (2 levels) in converge'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/runner.rb:85:in `each'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/runner.rb:85:in `block in converge'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/resource_collection.rb:94:in `block in execute_each_resource'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/resource_collection.rb:92:in `execute_each_resource'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/runner.rb:80:in `converge'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/client.rb:330:in `converge'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/client.rb:163:in `run'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/application/solo.rb:207:in `block in run_application'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/application/solo.rb:195:in `loop'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/application/solo.rb:195:in `run_application'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/lib/chef/application.rb:70:in `run'
/usr/local/lib/ruby/gems/1.9.1/gems/chef-0.10.10/bin/chef-solo:25:in `<top (required)>'
/usr/local/bin/chef-solo:23:in `load'
/usr/local/bin/chef-solo:23:in `<main>'
[2012-06-16T13:25:37-04:00] ERROR: Running exception handlers
[2012-06-16T13:25:37-04:00] ERROR: Exception handlers complete
[2012-06-16T13:25:37-04:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2012-06-16T13:25:37-04:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: service[mysql] (mysql::server line 103) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
---- Begin output of restart mysql ----
STDOUT: 
STDERR: restart: Job failed to restart
---- End output of restart mysql ----
Ran restart mysql returned 1
```
