### PR TITLE
Bugfix /etc/../my.cnf creation

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -85,6 +85,7 @@ unless platform?(%w{mac_os_x})
     group "mysql" unless platform? 'windows'
     action :create
     recursive true
+    retries 1
   end
 
   if platform? 'windows'


### PR DESCRIPTION
Creating the /etc/../my.cnf and setting its ownership on centos 6 is delaying on centos 6 and is returning the corresponding system error, so a retry is necessary
