### PR TITLE
COOK-1397: making port an attribute

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -18,6 +18,7 @@
 #
 
 default['mysql']['bind_address']               = attribute?('cloud') ? cloud['local_ipv4'] : ipaddress
+default['mysql']['port']                       = 3306
 
 case node["platform"]
 when "centos", "redhat", "fedora", "suse", "scientific", "amazon"

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -21,7 +21,7 @@
 # escpecially if they contain "#" chars...
 # Remember to edit /etc/mysql/debian.cnf when changing the socket location.
 [client]
-port            = 3306
+port            = <%= node['mysql']['port'] %>
 socket          = <%= node['mysql']['socket'] %>
 
 # Here is entries for some specific programs
@@ -46,7 +46,7 @@ nice            = 0
 user            = mysql
 pid-file        = <%= node['mysql']['pid_file'] %>
 socket          = <%= node['mysql']['socket'] %>
-port            = 3306
+port            = <%= node['mysql']['port'] %>
 basedir         = <%= node['mysql']['basedir'] %>
 datadir         = <%= node['mysql']['data_dir'] %>
 tmpdir          = /tmp


### PR DESCRIPTION
Add a couple of lines to make the mysqld port an attribute, which can then be overridden.
