### PR TITLE
Add attributes to control default collation and character set

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -148,3 +148,6 @@ default['mysql']['tunable']['long_query_time']      = 2
 
 default['mysql']['tunable']['expire_logs_days']     = 10
 default['mysql']['tunable']['max_binlog_size']      = "100M"
+
+default['mysql']['tunable']['default-character-set'] = "utf8"
+default['mysql']['tunable']['default-collation']     = "utf8_unicode_ci"

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -81,6 +81,13 @@ table_cache             = <%= node['mysql']['tunable']['table_cache'] %>
 max_heap_table_size     = <%= node['mysql']['tunable']['max_heap_table_size'] %>
 
 #
+# * Encoding and collation
+#
+
+default-character-set   = <%= node['mysql']['tunable']['default-character-set'] %>
+default-collation       = <%= node['mysql']['tunable']['default-collation'] %>
+
+#
 # * Query Cache Configuration
 #
 query_cache_limit       = <%= node['mysql']['tunable']['query_cache_limit'] %>


### PR DESCRIPTION
This would ensure that, when a new table is created, it uses the provided default collation and character set.
