### PR TITLE
[COOK-1479] Fixed the issue of older mysql-server version not supporting innodb_adaptive_flushing that causes the mysqld service to not start.

### DIFF
--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -142,7 +142,9 @@ innodb_file_per_table
 innodb_flush_log_at_trx_commit = <%= node['mysql']['tunable']['innodb_flush_log_at_trx_commit'] %>
 innodb_flush_method     = <%= node['mysql']['tunable']['innodb_flush_method'] %>
 innodb_log_buffer_size  = <%= node['mysql']['tunable']['innodb_log_buffer_size'] %>
+<% if node['mysql']['tunable']['innodb_adaptive_flushing']%>
 innodb_adaptive_flushing  = <%= node['mysql']['tunable']['innodb_adaptive_flushing'] %>
+<%end %>
 
 <% if @skip_federated %>
 #


### PR DESCRIPTION
... innodb_adaptive_flushing that causes the mysqld service to not start.
