### PR TITLE
Allow user to specify another cookbook for my.cnf template source

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -124,6 +124,9 @@ unless platform?(%w{mac_os_x})
 
   template "#{node['mysql']['conf_dir']}/my.cnf" do
     source "my.cnf.erb"
+    if node['mysql']['cookbook'] 
+      cookbook node['mysql']['cookbook']
+    end
     owner "root" unless platform? 'windows'
     group node['mysql']['root_group'] unless platform? 'windows'
     mode "0644"


### PR DESCRIPTION
have the template source for my.cnf be in another cookbook.

This allows me to modify the template to do whatever crazy stuff I need to do,
without significantly complicating the recipe, and leveraging all the great
things that the mysql cookbook already does.

To use set your own override

node['mysql']['cookbook'] = 'mycookbook'

and the recipe will fetch the my.cnf.erb from there.

My particular use case was that I want to disable innodb file per
table and a number of other changes.
