### PR TITLE
COOK-1610: Run execute[assign-root-password] via mysqladmin on all platforms

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -148,16 +148,12 @@ unless Chef::Config[:solo]
   end
 end
 
-# set the root password on platforms
-# that don't support pre-seeding
-unless platform?(%w{debian ubuntu})
-
-  execute "assign-root-password" do
-    command "\"#{node['mysql']['mysqladmin_bin']}\" -u root password \"#{node['mysql']['server_root_password']}\""
-    action :run
-    only_if "\"#{node['mysql']['mysql_bin']}\" -u root -e 'show databases;'"
-  end
-
+# set the root password for situations that don't support pre-seeding.
+# (eg. platforms other than debian/ubuntu & drop-in mysql replacements)
+execute "assign-root-password" do
+  command "\"#{node['mysql']['mysqladmin_bin']}\" -u root password \"#{node['mysql']['server_root_password']}\""
+  action :run
+  only_if "\"#{node['mysql']['mysql_bin']}\" -u root -e 'show databases;'"
 end
 
 # Homebrew has its own way to do databases


### PR DESCRIPTION
Allows drop-in mysql replacements to piggyback on mysql cookbook, even though preseed can't work for them.

http://tickets.opscode.com/browse/COOK-1610
