### PR TITLE
[COOK-1686] - start mysql service

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -194,4 +194,8 @@ else
       subscribes :run, resources("template[#{grants_path}]"), :immediately
     end
   end
+
+  service "mysql" do
+    action :start
+  end
 end


### PR DESCRIPTION
Add a mysql service resource. This should use the defaults from the earlier
defined mysql service resource.

The exception is the mysql service on mac_os_x, where it is not defined to start
at all.

This should be tested in test-kitchen (supported in the mysql cookbook).
