### PR TITLE
Update README link to point to opscode-cookbooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Resources and Providers
 
 The LWRP that used to ship as part of this cookbook has been
 refactored into the
-[database](https://github.com/opscode/cookbooks/tree/master/database)
+[database](https://github.com/opscode-cookbooks/database)
 cookbook. Please see the README for details on updated usage.
 
 Attributes


### PR DESCRIPTION
Opscode has reorganized their cookbooks, updating the database link.
