### PR TITLE
[COOK-1737] Fail a chef-solo run when passwords are not set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,21 +170,6 @@ The recipe will perform a `node.save` unless it is run under
 `chef-solo` after the password attributes are used to ensure that in
 the event of a failed run, the saved attributes would be used.
 
-**Chef Solo Note**: These node attributes are stored on the Chef
-  server when using `chef-client`. Because `chef-solo` does not
-  connect to a server or save the node object at all, to have the same
-  passwords persist across `chef-solo` runs, you must specify them in
-  the `json_attribs` file used. For example:
-
-    {
-      "mysql": {
-        "server_root_password": "iloverandompasswordsbutthiswilldo",
-        "server_repl_password": "iloverandompasswordsbutthiswilldo",
-        "server_debian_password": "iloverandompasswordsbutthiswilldo"
-      },
-      "run_list":["recipe[mysql::server]"]
-    }
-
 On EC2 nodes, use the `server_ec2` recipe and the mysql data dir will
 be set up in the ephmeral storage.
 
@@ -198,6 +183,24 @@ The client recipe is already included by server and 'default' recipes.
 For more infromation on the compile vs execution phase of a Chef run:
 
 * http://wiki.opscode.com/display/chef/Anatomy+of+a+Chef+Run
+
+Chef Solo Note
+==============
+
+These node attributes are stored on the Chef
+server when using `chef-client`. Because `chef-solo` does not
+connect to a server or save the node object at all, to have the same
+passwords persist across `chef-solo` runs, you must specify them in
+the `json_attribs` file used. For example:
+
+    {
+      "mysql": {
+        "server_root_password": "iloverandompasswordsbutthiswilldo",
+        "server_repl_password": "iloverandompasswordsbutthiswilldo",
+        "server_debian_password": "iloverandompasswordsbutthiswilldo"
+      },
+      "run_list":["recipe[mysql::server]"]
+    }
 
 License and Author
 ==================

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -21,10 +21,25 @@
 
 include_recipe "mysql::client"
 
-# generate all passwords
-node.set_unless['mysql']['server_debian_password'] = secure_password
-node.set_unless['mysql']['server_root_password']   = secure_password
-node.set_unless['mysql']['server_repl_password']   = secure_password
+if Chef::Config[:solo]
+  missing_attrs = %w{
+    server_debian_password server_root_password server_repl_password
+  }.select do |attr|
+    node["mysql"][attr].nil?
+  end.map { |attr| "node['mysql']['#{attr}']" }
+
+  if !missing_attrs.empty?
+    Chef::Application.fatal!([
+      "You must set #{missing_attrs.join(', ')} in chef-solo mode.",
+      "For more information, see https://github.com/opscode-cookbooks/mysql#chef-solo-note"
+    ].join(' '))
+  end
+else
+  # generate all passwords
+  node.set_unless['mysql']['server_debian_password'] = secure_password
+  node.set_unless['mysql']['server_root_password']   = secure_password
+  node.set_unless['mysql']['server_repl_password']   = secure_password
+end
 
 if platform?(%w{debian ubuntu})
 


### PR DESCRIPTION
**Currently being tracked as [COOK-1737](http://tickets.opscode.com/browse/COOK-1737)**

> I believe this gotcha snags a lot of people, despite being well documented in the cookbook's README. So despite all warnings many users (especially first time users) inevitably get locked out of the MySQL instance sooner or later. Then we all learn our lesson 
> 
> So submitted for the community's feedback, here's one solution: don't allow chef-solo runs to continue without setting these passwords.

The failure message contains a link to the cookbook's README section
which doesn't currently exist, hence the README update.
