### PR TITLE
COOK-1669: use node.platform?

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -102,7 +102,7 @@ end
 
 default['mysql']['reload_action'] = "restart" # or "reload" or "none"
 
-default['mysql']['use_upstart'] = platform?("ubuntu") && node.platform_version.to_f >= 10.04
+default['mysql']['use_upstart'] = node.platform?("ubuntu") && node.platform_version.to_f >= 10.04
 
 default['mysql']['auto-increment-increment']        = 1
 default['mysql']['auto-increment-offset']           = 1


### PR DESCRIPTION
On Chef 10 calling 'platform?' in an attribute file actually creates an
attribute called platform? because this method is in the language mixin
that is loaded in recipes, not on the node.
