### PR TITLE
[COOK-2158] Let build-essential handle apt-get at compile time

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ recipe            "mysql::server_ec2", "Performs EC2-specific mountpoint manipul
 end
 
 depends "openssl"
-depends "build-essential"
+depends "build-essential", "> 1.1.0"
 suggests "homebrew"
 suggests "windows"
 

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -20,11 +20,6 @@
 # limitations under the License.
 #
 
-execute "apt-get update" do
-  ignore_failure true
-  action :nothing
-end.run_action(:run) if node['platform_family'] == "debian"
-
 node.set['build_essential']['compiletime'] = true
 include_recipe "build-essential"
 include_recipe "mysql::client"


### PR DESCRIPTION
`build-essential` [does this for us](https://github.com/opscode-cookbooks/build-essential/commit/6377ae8f8e7c4204524e0060f34b34870df2ad22) since version [`1.1.0`](https://github.com/opscode-cookbooks/build-essential/commit/5784c5215721156d245b23b5ff83e7a80c870dfc).

See http://tickets.opscode.com/browse/COOK-1296
