### PR TITLE
[COOK-1851]  Add support for server-id and binlog_format in configuration file

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -124,8 +124,11 @@ default['mysql']['tunable']['thread_concurrency']   = 10
 default['mysql']['tunable']['thread_stack']         = "256K"
 default['mysql']['tunable']['wait_timeout']         = "180"
 
+
+default['mysql']['tunable']['server_id']                       = nil
 default['mysql']['tunable']['log_bin']                         = nil
 default['mysql']['tunable']['log_bin_trust_function_creators'] = false
+default['mysql']['tunable']['binlog_format']                   = "statement"
 default['mysql']['tunable']['relay_log']                       =  nil
 default['mysql']['tunable']['log_slave_updates']               = false
 default['mysql']['tunable']['sync_binlog']                     = 0

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -107,7 +107,12 @@ log-queries-not-using-indexes
 # The following can be used as easy to replay backup logs or for replication.
 # note: if you are setting up a replication slave, see README.Debian about
 #       other settings you may need to change.
-#server-id              = 1
+<%- if node['mysql']['tunable']['server_id'] %>
+server-id = <%= node['mysql']['tunable']['server_id'] %>
+<% end %>
+
+binlog_format = <%= node['mysql']['tunable']['binlog_format'] %>
+
 <%- if node['mysql']['tunable']['log_bin'] %>
 log_bin = <%= node['mysql']['tunable']['log_bin'] %>
 log_slave_updates       = <%= node['mysql']['tunable']['log_slave_updates'] %>


### PR DESCRIPTION
For replication purpose two settings are usefull:

server-id (mandatory):
http://dev.mysql.com/doc/refman/5.5/en/replication-options.html#option_mysqld_server-id

binlog_format
http://dev.mysql.com/doc/refman/5.6/en/replication-options-binary-log.html#sysvar_binlog_format

http://tickets.opscode.com/browse/COOK-1851
