### PR TITLE
[COOK-1929] fix erroneous boolean query which checks if current platform is ubuntu

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -102,7 +102,7 @@ end
 
 default['mysql']['reload_action'] = "restart" # or "reload" or "none"
 
-default['mysql']['use_upstart'] = node.platform?("ubuntu") && node.platform_version.to_f >= 10.04
+default['mysql']['use_upstart'] = node.platform.include?("ubuntu") && node.platform_version.to_f >= 10.04
 
 default['mysql']['auto-increment-increment']        = 1
 default['mysql']['auto-increment-offset']           = 1


### PR DESCRIPTION
This doesn´t return a boolean value as expected:

node.platform?("ubuntu")              //returns the the argument itself "ubuntu"
node.platform?("ubuntu").class  // returns the type String

node.platform?("centos")              //returns the the argument itself "centos"
node.platform?("centos").class  // returns the type String

But this is working fine:

node.platform.include?("ubuntu")

In my case we have centos running as platform so the following sequence validates my observation:

node.platform.include?("ubuntu")    // false  (boolean)
node.platform.include?("centos")    // true   (boolean)
node.platform                                      // centos (String)
