### PR TITLE
Fix for platform conditional for use_upstart. [COOK-1669]

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -117,7 +117,7 @@ end
 
 default['mysql']['reload_action'] = "restart" # or "reload" or "none"
 
-default['mysql']['use_upstart'] = node.platform?("ubuntu") && node['platform_version'].to_f >= 10.04
+default['mysql']['use_upstart'] = node.platform == "ubuntu" && node['platform_version'].to_f >= 10.04
 
 default['mysql']['auto-increment-increment']        = 1
 default['mysql']['auto-increment-offset']           = 1


### PR DESCRIPTION
 This was always evaluating to true on Amazon linux, which was a PITA.  
