### PR TITLE
Change default timeouts to prevent connection pooling issues. 

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -137,7 +137,8 @@ default['mysql']['tunable']['thread_cache']         = "128"
 default['mysql']['tunable']['thread_cache_size']    = 8
 default['mysql']['tunable']['thread_concurrency']   = 10
 default['mysql']['tunable']['thread_stack']         = "256K"
-default['mysql']['tunable']['wait_timeout']         = "180"
+default['mysql']['tunable']['wait_timeout']         = "28800"
+default['mysql']['tunable']['interactive_timeout']  = "180"
 
 
 default['mysql']['tunable']['server_id']                       = nil

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -74,6 +74,7 @@ myisam-recover          = BACKUP
 #thread_concurrency     = 10
 max_connections         = <%= node['mysql']['tunable']['max_connections'] %>
 wait_timeout            = <%= node['mysql']['tunable']['wait_timeout'] %>
+interactive_timeout     = <%= node['mysql']['tunable']['interactive_timeout'] %>
 net_read_timeout        = <%= node['mysql']['tunable']['net_read_timeout'] %>
 net_write_timeout       = <%= node['mysql']['tunable']['net_write_timeout'] %>
 back_log                = <%= node['mysql']['tunable']['back_log'] %>


### PR DESCRIPTION
Change default['mysql']['tunable']['wait_timeout']  = "28800"
Add attribute default['mysql']['tunable']['interactive_timeout']  = "180".
Update my.cnf.erb template to reflect new attribute.
wait_timeout is for non-interactive clients and a longer timeout is more appropriate. Caused a problem attempting to use MySQL as the database for a GateIn-3.5.0.Beta02 installation but really any JDBC connection pooling would likely have an issue with the old default (180 seconds). New attribute added to reflect the assumed spirit of the original but which only affects interactive clients. 
