### PR TITLE
Fix COOK-1929

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -117,7 +117,7 @@ end
 
 default['mysql']['reload_action'] = "restart" # or "reload" or "none"
 
-default['mysql']['use_upstart'] = node.platform?("ubuntu") && node['platform_version'].to_f >= 10.04
+default['mysql']['use_upstart'] = (node.platform == "ubuntu") && node['platform_version'].to_f >= 10.04
 
 default['mysql']['auto-increment-increment']        = 1
 default['mysql']['auto-increment-offset']           = 1

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -21,11 +21,11 @@ module Opscode
     module Helpers
 
       def debian_before_squeeze?
-        platform?("debian") && (node.platform_version.to_f < 6.0)
+        (node.platform == "debian") && (node.platform_version.to_f < 6.0)
       end
 
       def ubuntu_before_lucid?
-        platform?("ubuntu") && (node.platform_version.to_f < 10.0)
+        (node.platform == "ubuntu") && (node.platform_version.to_f < 10.0)
       end
 
     end


### PR DESCRIPTION
Competing solution for COOK-1929:
- Include also library helpers which trigger the same warning
- Use equality test instead of `.include?`, which seems to have been original intention
