### PR TITLE
my.cnf issues with changed options / configuration keys

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -129,8 +129,8 @@ default['mysql']['auto-increment-increment']        = 1
 default['mysql']['auto-increment-offset']           = 1
 
 default['mysql']['allow_remote_root']               = false
-default['mysql']['tunable']['character-set-server'] = "utf8"
-default['mysql']['tunable']['collation-server']     = "utf8_general_ci"
+default['mysql']['tunable']['character_set_server'] = "utf8"
+default['mysql']['tunable']['collation_server']     = "utf8_general_ci"
 default['mysql']['tunable']['back_log']             = "128"
 default['mysql']['tunable']['key_buffer']           = "256M"
 default['mysql']['tunable']['myisam_sort_buffer_size']   = "8M"
@@ -159,8 +159,8 @@ default['mysql']['tunable']['read_buffer_size']     = "128k"
 default['mysql']['tunable']['read_rnd_buffer_size'] = "256k"
 default['mysql']['tunable']['join_buffer_size']     = "128k"
 default['mysql']['tunable']['wait_timeout']         = "180"
-default['mysql']['tunable']['open-files-limit']     = "8192"
-default['mysql']['tunable']['open-files']           = "1024"
+default['mysql']['tunable']['open_files_limit']     = "8192"
+default['mysql']['tunable']['open_files']           = "1024"
 
 default['mysql']['tunable']['sql_mode'] = nil
 

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -56,8 +56,8 @@ skip-name-resolve
 <%- end %>
 
 # Charset and Collation
-character-set-server = <%= node['mysql']['tunable']['character-set-server'] %>
-collation-server     = <%= node['mysql']['tunable']['collation-server'] %>
+character_set_server = <%= node['mysql']['tunable']['character_set_server'] %>
+collation_server     = <%= node['mysql']['tunable']['collation_server'] %>
 <%- if node['mysql']['tunable']['event_scheduler'] %>
 event_scheduler      = <%= node['mysql']['tunable']['event_scheduler'] %>
 <%- end %>
@@ -81,12 +81,12 @@ read_buffer_size        = <%= node['mysql']['tunable']['read_buffer_size'] %>
 read_rnd_buffer_size    = <%= node['mysql']['tunable']['read_rnd_buffer_size'] %>
 join_buffer_size        = <%= node['mysql']['tunable']['join_buffer_size'] %>
 
-auto-increment-increment = <%= node['mysql']['auto-increment-increment'] %>
-auto-increment-offset    = <%= node['mysql']['auto-increment-offset'] %>
+auto_increment_increment = <%= node['mysql']['auto_increment_increment'] %>
+auto_increment_offset    = <%= node['mysql']['auto_increment_offset'] %>
 
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched
-myisam-recover          = BACKUP
+myisam_recover_options  = BACKUP
 max_connections         = <%= node['mysql']['tunable']['max_connections'] %>
 max_connect_errors      = <%= node['mysql']['tunable']['max_connect_errors'] %>
 concurrent_insert       = <%= node['mysql']['tunable']['concurrent_insert'] %>
@@ -102,8 +102,8 @@ table_open_cache        = <%= node['mysql']['tunable']['table_open_cache'] %>
 tmp_table_size          = <%= node['mysql']['tunable']['tmp_table_size'] %>
 max_heap_table_size     = <%= node['mysql']['tunable']['max_heap_table_size'] %>
 bulk_insert_buffer_size = <%= node['mysql']['tunable']['bulk_insert_buffer_size'] %>
-open-files-limit        = <%= node['mysql']['tunable']['open-files-limit'] %>
-open-files              = <%= node['mysql']['tunable']['open-files'] %>
+open_files_limit        = <%= node['mysql']['tunable']['open_files_limit'] %>
+open_files              = <%= node['mysql']['tunable']['open_files'] %>
 
 # Default Table Settings
 <%- if node['mysql']['tunable']['sql_mode'] %>


### PR DESCRIPTION
replace dashes with underscores in a few of the configuration options

On Ubuntu 12.04, with chef 10.12, I was unable to get mysql working without making these changes
