### PR TITLE
COOK-2145 - Delete anonymous accounts via attribute

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -169,3 +169,7 @@ default['mysql']['tunable']['long_query_time']      = 2
 
 default['mysql']['tunable']['expire_logs_days']     = 10
 default['mysql']['tunable']['max_binlog_size']      = "100M"
+
+default['mysql']['delete_anonymous_users']          =  true
+default['mysql']['delete_passwordless_users']       =  true
+

--- a/templates/default/grants.sql.erb
+++ b/templates/default/grants.sql.erb
@@ -13,3 +13,11 @@ GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%' identified by '<%= node['mysql']['s
 GRANT ALL ON *.* TO 'root'@'%' IDENTIFIED BY '<%= node['mysql']['server_root_password'] %>' WITH GRANT OPTION;
 <% end -%>
 SET PASSWORD FOR 'root'@'localhost' = PASSWORD('<%= node['mysql']['server_root_password'] %>');
+
+<% if node['mysql']['delete_anonymous_users'] -%>
+DELETE FROM mysql.user WHERE User=''; FLUSH PRIVILEGES;
+<% end -%>
+
+<% if node['mysql']['delete_passwordless_users'] -%>
+DELETE FROM mysql.user WHERE Password=''; FLUSH PRIVILEGES;
+<% end -%>


### PR DESCRIPTION
Added two new attributes which when true will remove these accounts which could present a security issue

default['mysql']['delete_anonymous_users']          =  true
default['mysql']['delete_passwordless_users']      =  true
