### PR TITLE
Enable includedir for any platform

### DIFF
--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -303,8 +303,9 @@ skip-bdb
 # Default to using old password format for compatibility with mysql 3.x
 # clients (those using the mysqlclient10 compatibility package).
 old_passwords           = <%= node['mysql']['old_passwords'] %>
+<% end -%>
 
-<% else -%>
+<% if node['mysql']['confd_dir'] -%>
 #
 # * IMPORTANT: Additional settings that can override those from this file!
 #   The files must end with '.cnf', otherwise they'll be ignored.


### PR DESCRIPTION
The decision to set an include directory should not depend on which OS you are using. As it stands currently, rhel, fedora and suse are unable to use the include dir.
