### PR TITLE
[COOK-2557] Fix mysql::percona_repo apt_repository typos and add attributes

### DIFF
--- a/attributes/percona_repo.rb
+++ b/attributes/percona_repo.rb
@@ -1,0 +1,3 @@
+default['mysql']['percona']['apt_key_id'] = 'CD2EFD2A'
+default['mysql']['percona']['apt_uri'] = "http://repo.percona.com/apt"
+default['mysql']['percona']['apt_keyserver'] = "keys.gnupg.net"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures mysql for client or server"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "2.1.2"
+version           "2.1.3"
 recipe            "mysql", "Includes the client recipe to configure a client"
 recipe            "mysql::client", "Installs packages required for mysql clients using run_action magic"
 recipe            "mysql::server", "Installs packages required for mysql servers w/o manual intervention"

--- a/recipes/percona_repo.rb
+++ b/recipes/percona_repo.rb
@@ -22,11 +22,11 @@ case node['platform']
 when "ubuntu", "debian"
   include_recipe "apt"
   apt_repository "percona" do
-    uri "http://repo.percona.com/apt"
+    uri node['mysql']['percona']['apt_uri']
     distribution node['lsb']['codename']
     components [ "main" ]
-    keyserver "kyes.gnupg.net"
-    key node['mysql']['percona']['key_id']
+    keyserver node['mysql']['percona']['apt_keyserver'] 
+    key node['mysql']['percona']['apt_key_id']
     action :add
   end
 when "centos", "amazon", "redhat"


### PR DESCRIPTION
Per COOK-2557, the mysql::percona_repo was broken for users of apt.  This commit fixes them and attributifies a few other parameters.
