### PR TITLE
COOK-2617 - Removing duplicate variable open-files

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -173,8 +173,7 @@ default['mysql']['tunable']['read_buffer_size']     = "128k"
 default['mysql']['tunable']['read_rnd_buffer_size'] = "256k"
 default['mysql']['tunable']['join_buffer_size']     = "128k"
 default['mysql']['tunable']['wait_timeout']         = "180"
-default['mysql']['tunable']['open-files-limit']     = "8192"
-default['mysql']['tunable']['open-files']           = "1024"
+default['mysql']['tunable']['open-files-limit']     = "1024"
 
 default['mysql']['tunable']['sql_mode'] = nil
 

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -109,7 +109,6 @@ tmp_table_size          = <%= node['mysql']['tunable']['tmp_table_size'] %>
 max_heap_table_size     = <%= node['mysql']['tunable']['max_heap_table_size'] %>
 bulk_insert_buffer_size = <%= node['mysql']['tunable']['bulk_insert_buffer_size'] %>
 open-files-limit        = <%= node['mysql']['tunable']['open-files-limit'] %>
-open-files              = <%= node['mysql']['tunable']['open-files'] %>
 
 # Default Table Settings
 <%- if node['mysql']['tunable']['sql_mode'] %>


### PR DESCRIPTION
Setting open-files-limit to 1024 instead of 8192 as 1024 appears to be
the default upon install.
