### PR TITLE
COOK-2619 - Rename isamchk to myisamchk

### DIFF
--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -276,7 +276,7 @@ max_allowed_packet      = <%= node['mysql']['tunable']['max_allowed_packet'] %>
 [mysql]
 #no-auto-rehash # faster start of mysql but no tab completition
 
-[isamchk]
+[myisamchk]
 key_buffer                = <%= node['mysql']['tunable']['max_allowed_packet'] %>
 
 myisam_sort_buffer_size   = <%= node['mysql']['tunable']['myisam_sort_buffer_size'] %>


### PR DESCRIPTION
ISAM was removed from binary packages in 4.1
http://dev.mysql.com/doc/refman/4.1/en/isam-storage-engine.html
