### PR TITLE
[COOK-2430] Add a tunable to create a network ACL when allowing remote_root_access

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ platform and version.
 * `node['mysql']['socket']` - Path to the mysqld.sock file
 * `node['mysql']['use_upstart']` - Whether to use upstart for the
   service provider
+* `mysql['root_network_acl']` - Set define the network the root user will be able to login from, default is nil
 
 Performance and other "tunable" attributes are under the
 `node['mysql']['tunable']` attribute, corresponding to the same-named

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -143,6 +143,7 @@ default['mysql']['auto-increment-increment']        = 1
 default['mysql']['auto-increment-offset']           = 1
 
 default['mysql']['allow_remote_root']               = false
+default['mysql']['root_network_acl']                = nil
 default['mysql']['tunable']['character-set-server'] = "utf8"
 default['mysql']['tunable']['collation-server']     = "utf8_general_ci"
 default['mysql']['tunable']['back_log']             = "128"

--- a/templates/default/grants.sql.erb
+++ b/templates/default/grants.sql.erb
@@ -13,3 +13,8 @@ GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%' identified by '<%= node['mysql']['s
 GRANT ALL ON *.* TO 'root'@'%' IDENTIFIED BY '<%= node['mysql']['server_root_password'] %>' WITH GRANT OPTION;
 <% end -%>
 SET PASSWORD FOR 'root'@'localhost' = PASSWORD('<%= node['mysql']['server_root_password'] %>');
+
+# allow root to connect from a remote network if root_network_acl is not nil
+<% if node['mysql']['root_network_acl'] -%>
+SET PASSWORD FOR 'root'@'<%= node['mysql']['root_network_acl'] %>' = PASSWORD('<%= node['mysql']['server_root_password'] %>');
+<% end -%>


### PR DESCRIPTION
This pull request adds a tunable (root_network_acl) to permit root access the network. Currently this cookbook only allows remote root access from localhost. This extends it so that you can set root_network_acl to an ipaddress/netmask such as 192.168.1.0/255.255.255.0 and the grants.sql file is updated accordingly.

By default this is set to nil and no remote root access is permitted.
