### PR TITLE
[COOK-2801] Fix the uid/gid of mysql by attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ See the `attributes/server.rb` or `attributes/client.rb` for default values. Sev
 * `node['mysql']['use_upstart']` - Whether to use upstart for the
   service provider
 * `mysql['root_network_acl']` - Set define the network the root user will be able to login from, default is nil
+* `node['mysql']['uid']` and `node['mysql']['gid']` - Use this to fix the
+  uid/gid of the mysql User (nil is default)
 
 Performance and other "tunable" attributes are under the `node['mysql']['tunable']` attribute, corresponding to the same-named parameter in my.cnf, and the default values are used. See `attributes/server.rb`.
 

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -253,6 +253,9 @@ default['mysql']['log_dir'] = node['mysql']['data_dir']
 default['mysql']['log_files_in_group'] = false
 default['mysql']['innodb_status_file'] = false
 
+default['mysql']['uid'] = nil
+default['mysql']['gid'] = nil
+
 unless node['platform_family'] == 'rhel' && node['platform_version'].to_i < 6
   # older RHEL platforms don't support these options
   default['mysql']['tunable']['event_scheduler']  = 0

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -89,11 +89,12 @@ end
 unless platform_family?('windows')
   group 'mysql' do
     action :create
+    gid node['mysql']['gid'] if node['mysql']['gid']
   end
-
   user 'mysql' do
     comment 'MySQL Server'
     gid     'mysql'
+    uid     node['mysql']['uid'] if node['mysql']['uid']
     system  true
     home    node['mysql']['data_dir']
     shell   '/sbin/nologin'


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-2801
- node['mysql']['uid'] and node['mysql']['gid'] are nil by default
- if not nil, the user will be created before the package is installed
