### PR TITLE
COOK-2995 server.rb is missing a platform_family comparison value

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -247,7 +247,7 @@ default['mysql']['log_dir'] = node['mysql']['data_dir']
 default['mysql']['log_files_in_group'] = false
 default['mysql']['innodb_status_file'] = false
 
-unless node['platform_family'] && node['platform_version'].to_i < 6
+unless node['platform_family'] == "rhel" && node['platform_version'].to_i < 6
   # older RHEL platforms don't support these options
   default['mysql']['tunable']['event_scheduler']  = 0
   default['mysql']['tunable']['table_open_cache'] = "128"


### PR DESCRIPTION
This code does not do what you wanted it to do :)

unless node['platform_family'] && node['platform_version'].to_i < 6
  # older RHEL platforms don't support these options
  # ...

Note missing intended RHS of comparison for platform_family.
