### PR TITLE
Use the distribution ruby-mysql package under Debian 7.0

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -20,12 +20,17 @@
 # limitations under the License.
 #
 
-node.set['build_essential']['compiletime'] = true
-include_recipe "build-essential"
 include_recipe "mysql::client"
 
 node['mysql']['client']['packages'].each do |mysql_pack|
   resources("package[#{mysql_pack}]").run_action(:install)
 end
 
-chef_gem "mysql"
+if node['platform_family'] == "debian" and node['platform_version'].to_f >= 7.0
+  resources("package[ruby-mysql]").run_action(:install)
+else
+  node.set['build_essential']['compiletime'] = true
+  include_recipe "build-essential"
+
+  chef_gem "mysql"
+end


### PR DESCRIPTION
There is no need to build the MySQL gem by ourselves when it is readily
available from the distro repositories.

It is faster and easier to use the distro package, as:
- it doesn't involve downloading a lot of build-related packages
- there is no compilation error due to missing headers or other cryptic messages for non-ruby-developpers. 

Alternatively, the recipe should ensure ruby-dev is installed before attempting to build the gem.
