### PR TITLE
[COOK-3149] my.cnf should be created before install

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -100,6 +100,7 @@ unless platform_family?(%w{windows})
   user "mysql" do
     comment "MySQL Server"
     gid "mysql"
+    system true
     home node['mysql']['data_dir']
     shell "/sbin/nologin"
   end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3149.

Note only tested against CentOS v6 and this is a significant alteration.
