### PR TITLE
[COOK-3310] Missing grant option for root

### DIFF
--- a/templates/default/grants.sql.erb
+++ b/templates/default/grants.sql.erb
@@ -36,5 +36,5 @@ SET PASSWORD FOR 'root'@'localhost' = PASSWORD('<%= node['mysql']['server_root_p
 <% if node['mysql']['root_network_acl'] -%>
 
 # allow root to connect from a remote network if root_network_acl is not nil
-GRANT ALL PRIVILEGES ON *.* TO 'root'@'<%= node['mysql']['root_network_acl'] %>' IDENTIFIED BY '<%= node['mysql']['server_root_password'] %>'
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'<%= node['mysql']['root_network_acl'] %>' IDENTIFIED BY '<%= node['mysql']['server_root_password'] %>' WITH GRANT OPTION;
 <% end -%>


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3310

`WITH GRANT OPTION` was left off of the root access via acl.
