### PR TITLE
[COOK-3390] Create directory /etc/mysql

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -64,6 +64,13 @@ if platform_family?(%w{debian})
     notifies :run, "execute[preseed mysql-server]", :immediately
   end
 
+  directory "#{node['mysql']['conf_dir']}" do
+    owner "mysql"
+    group "mysql"
+    mode "0600"
+    action :create
+  end
+
   template "#{node['mysql']['conf_dir']}/debian.cnf" do
     source "debian.cnf.erb"
     owner "root"


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3390

This is because when I did an (for cleanup and test cookbook):

aptitude purge mysql-client mysql-common mysql-server mysql-server-5.5
rm -R /var/lib/mysql/
rm -R /etc/mysql/
mkdir /etc/mysql

chef-client runs stops at template "#{node['mysql']['conf_dir']}/debian.cnf" do

because /etc/mysql is not present.

I think that it is wrong. And Author should check a directory in recipe and fix it recipe.

Thank you.

Client ubuntu 12.04.2 with all updates
