### PR TITLE
[COOK-3536] Extra check to make sure cloud local_ipv4 actually exist

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default['mysql']['bind_address']               = node.attribute?('cloud') ? node.cloud['local_ipv4'] : node['ipaddress']
+default['mysql']['bind_address']               = node.attribute?('cloud') && node.cloud['local_ipv4'] ? node.cloud['local_ipv4'] : node['ipaddress']
 default['mysql']['port']                       = 3306
 default['mysql']['nice']                       = 0
 


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3536

Mysql fails to install on Linode because of cloud local_ipv4 attribute 

I spent couple days figuring out this issue. Turned out that on Linode node.attribute?('cloud') == true, node.cloud['local_ipv4'] is not set.

As the result mysql just wont start with socket error.

More details here:

http://distinctplace.com/infrastructure/2013/08/28/percona-mysql-install-problem-with-chef-on-linode---be-aware/

Here is the output of linode cloud attributes:

"cloud": { "public_ips": [ "176.56.102.37" ], "private_ips": [ null ], "public_ipv4": null, "public_hostname": null, "local_ipv4": null, "local_hostname": null, "provider": "linode" }
