### PR TITLE
[COOK-3674] Fixed issue with root pwd

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -46,3 +46,10 @@ suites:
   - recipe[minitest-handler]
   - recipe[mysql_test::server]
   attributes: {}
+- name: server-nondefault-data
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[mysql_test::server]
+  attributes:
+    mysql:
+      data_dir: "/data/mysql"


### PR DESCRIPTION
Found an issue: https://tickets.opscode.com/browse/COOK-3674

This fix is the first step toward fixing that. I also added a new set of
regression tests for a non-default data_dir value.

Note: Currently the mysql cookbook breaks on debian when using something other than the default data_dir. My change will also give someone a way to validate there fix (https://tickets.opscode.com/browse/COOK-3527)
