### PR TITLE
[COOK-3773] Fixing immediate restarts on template

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -131,7 +131,8 @@ unless platform_family?('mac_os_x')
                      false
                    end
 
-  template "#{node['mysql']['conf_dir']}/my.cnf" do
+  template 'initial-my.cnf' do
+    path "#{node['mysql']['conf_dir']}/my.cnf"
     source 'my.cnf.erb'
     owner 'root' unless platform? 'windows'
     group node['mysql']['root_group'] unless platform?('windows')
@@ -191,7 +192,9 @@ else
     action       :enable
   end
 
-  template "#{node['mysql']['conf_dir']}/my.cnf" do
+unless platform_family?('mac_os_x')
+  template 'final-my.cnf' do
+    path "#{node['mysql']['conf_dir']}/my.cnf"
     source 'my.cnf.erb'
     owner 'root' unless platform? 'windows'
     group node['mysql']['root_group'] unless platform? 'windows'


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3773
- Fix immediate restarts called by initial `my.cnf` template
