### PR TITLE
[COOK-3801] Add innodb_adaptive_flushing_method and innodb_adaptive_checkpoint

### DIFF
--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -268,6 +268,12 @@ innodb_log_buffer_size  = <%= node['mysql']['tunable']['innodb_log_buffer_size']
 <%- if node['mysql']['tunable']['innodb_adaptive_flushing'] %>
 innodb_adaptive_flushing  = <%= node['mysql']['tunable']['innodb_adaptive_flushing'] %>
 <%- end %>
+<%- if node['mysql']['tunable']['innodb_adaptive_flushing_method'] %>
+innodb_adaptive_flushing_method = <%= node['mysql']['tunable']['innodb_adaptive_flushing_method'] %>
+<%- end %>
+<%- if node['mysql']['tunable']['innodb_adaptive_checkpoint'] %>
+innodb_adaptive_checkpoint = <%= node['mysql']['tunable']['innodb_adaptive_checkpoint'] %>
+<%- end %>
 
 <% if @skip_federated %>
 #


### PR DESCRIPTION
The following tuning is useful for optimizing DB workloads on flash storage, Fusion IO devices, SSDs, etc.  They are useful only for people using Percona or MariaDB.

innodb_adaptive_checkpoint on 5.1 is the same as innodb_adaptive_flushing_method on 5.5:

http://www.percona.com/doc/percona-server/5.5/scalability/innodb_io_55.html#innodb_adaptive_flushing_method

http://www.percona.com/doc/percona-server/5.1/scalability/innodb_io.html?id=percona-server:features:innodb_io_51&redirect=1#innodb_adaptive_checkpoint
