### PR TITLE
Update Debian.cnf.erb template to use the ['mysql']['basedir'] attribute...

### DIFF
--- a/templates/default/debian.cnf.erb
+++ b/templates/default/debian.cnf.erb
@@ -9,4 +9,4 @@ host     = localhost
 user     = debian-sys-maint
 password = <%= node['mysql']['server_debian_password'] %>
 socket   = <%= node['mysql']['socket'] %>
-basedir  = /usr
+basedir  = <%= node['mysql']['basedir'] %>


### PR DESCRIPTION
....

Currently ['mysql']['basedir'] can be set but it has no effect on the basedir used in this template. This change will allow it to be set dynamically.
