### PR TITLE
Support server root passwords that contain spaces

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -38,7 +38,7 @@ module Opscode
       def install_grants_cmd
         str = '/usr/bin/mysql'
         str << ' -u root '
-        node['mysql']['server_root_password'].empty? ? str << ' < /etc/mysql_grants.sql' : str << " -p\"#{node['mysql']['server_root_password']}\" < /etc/mysql_grants.sql"
+        node['mysql']['server_root_password'].empty? ? str << ' < /etc/mysql_grants.sql' : str << " -p'#{node['mysql']['server_root_password']}' < /etc/mysql_grants.sql"
       end
     end
   end


### PR DESCRIPTION
Importing `/etc/mysql_grants.sql` fails if the `server_root_password` contains spaces. This pull adds quotes around the password.
