### PR TITLE
Server recipe broken on Debian

### DIFF
--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -100,7 +100,7 @@ end
 # debian package still has traditional init script
 template '/etc/init/mysql.conf' do
   source 'init-mysql.conf.erb'
-  only_if node['platform_family'] == 'ubuntu'
+  only_if { node['platform_family'] == 'ubuntu' }
 end
 
 template '/etc/apparmor.d/usr.sbin.mysqld' do


### PR DESCRIPTION
The _server_debian.rb recipe is assuming you're on a Ubuntu system. It tries to put an upstart script in place even though there isn't one for Debian within the cookbook. I've added a check for Ubuntu & now you can actually install the server on Wheezy.

The Debian package installs an init script anyway so an alternative template isn't needed. 

Also, the recipe changes the debian-sys-maint password via the grants.sql, but never actually uses the debian.cnf.erb default template. I've included that too.

The _server_debian.rb was also loosening permissions on a number of mysql directories when compared with how they come when installed by the debian package. Along with the security implications, a side effect of this was that logrotate was broken for the MySQL logfiles under /var/log/mysql. These have now been matched up to the permissions which the package sets them.
