### PR TITLE
added restart action if bind_address != 127.0.0.1

### DIFF
--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -90,13 +90,20 @@ service 'apparmor-mysql' do
   supports :reload => true
 end
 
+# notify should restart if bind_address is overridden
+if node['mysql']['bind_address'] != '127.0.0.1'
+  notify_action = 'restart'
+else
+  notify_action = 'reload'
+end
+
 template '/etc/mysql/my.cnf' do
   source 'my.cnf.erb'
   owner 'root'
   group 'root'
   mode '0644'
   notifies :run, 'bash[move mysql data to datadir]', :immediately
-  notifies :reload, 'service[mysql]'
+  notifies notify_action, 'service[mysql]'
 end
 
 # don't try this at home


### PR DESCRIPTION
An action of reload doesn't have any effect if one is overriding the bind_address. This is a problem when first provisioning the node as one has to somehow restart mysql. This patch solves this; however it may not have been done in the best way.
