### PR TITLE
[COOK-4068] Fix MySQL installation on Windows.

### DIFF
--- a/attributes/server_windows.rb
+++ b/attributes/server_windows.rb
@@ -1,20 +1,22 @@
 case node['platform_family']
 when 'windows'
-  default['mysql']['windows']['package_file']       = "mysql-#{mysql['version']}-#{mysql['arch']}.msi"
+  default['mysql']['windows']['version']            = '5.5.34'
+  default['mysql']['windows']['arch']               = node['kernel']['machine'] == 'x86_64' ? 'winx64' : 'win32'
+  default['mysql']['windows']['package_file']       = "mysql-#{node['mysql']['windows']['version']}-#{node['mysql']['windows']['arch']}.msi"
   default['mysql']['windows']['packages']           = ['MySQL Server 5.5']
-  default['mysql']['windows']['url']                = "http://www.mysql.com/get/Downloads/MySQL-5.5/#{mysql['package_file']}/from/http://mysql.mirrors.pair.com/"
-  default['mysql']['windows']['version']            = '5.5.32'
-#  default['mysql']['windows']['arch']              = 'win32'
+  default['mysql']['windows']['url']                = "http://dev.mysql.com/get/Downloads/MySQL-5.5/#{node['mysql']['windows']['package_file']}"
 
-  default['mysql']['windows']['basedir']            = "#{ENV['SYSTEMDRIVE']}\\Program Files (x86)\\MySQL\\#{mysql['server']['packages'].first}"
-  default['mysql']['windows']['data_dir']           = "#{node['mysql']['windows']['basedir']}\\Data"
+  default['mysql']['windows']['programdir']         = node['kernel']['machine'] == 'x86_64' ? 'Program Files' : 'Program Files (x86)'
+  default['mysql']['windows']['basedir']            = "#{ENV['SYSTEMDRIVE']}\\#{node['mysql']['windows']['programdir']}\\MySQL\\#{node['mysql']['windows']['packages'].first}"
+  default['mysql']['windows']['data_dir']           = "#{ENV['ProgramData']}\\MySQL\\#{node['mysql']['windows']['packages'].first}\\Data"
   default['mysql']['windows']['bin_dir']            = "#{node['mysql']['windows']['basedir']}\\bin"
   default['mysql']['windows']['mysqladmin_bin']     = "#{node['mysql']['windows']['bin_dir']}\\mysqladmin"
   default['mysql']['windows']['mysql_bin']          = "#{node['mysql']['windows']['bin_dir']}\\mysql"
 
   default['mysql']['windows']['conf_dir']           = node['mysql']['windows']['basedir']
   default['mysql']['windows']['old_passwords']      = 0
-  default['mysql']['windows']['grants_path']        = "#{node['mysql']['conf_dir']}\\grants.sql"
+  default['mysql']['windows']['grants_path']        = "#{node['mysql']['windows']['conf_dir']}\\grants.sql"
 
   default['mysql']['server']['service_name']        = 'mysql'
+  default['mysql']['server']['slow_query_log']      = 1
 end

--- a/recipes/_server_windows.rb
+++ b/recipes/_server_windows.rb
@@ -1,15 +1,9 @@
 require 'win32/service'
-require 'win32/service'
 
 ENV['PATH'] += ";#{node['mysql']['windows']['bin_dir']}"
-package_file = Chef::Config[:file_cache_path] + node['mysql']['windows']['package_file']
+package_file = Chef::Config[:file_cache_path] + File::ALT_SEPARATOR + node['mysql']['windows']['package_file']
 install_dir = win_friendly_path(node['mysql']['windows']['basedir'])
 
-def package(*args, &blk)
-  windows_package(*args, &blk)
-end
-
-#----
 windows_path node['mysql']['windows']['bin_dir'] do
   action :add
 end
@@ -25,99 +19,46 @@ windows_package node['mysql']['windows']['packages'].first do
   notifies :run, 'execute[install mysql service]', :immediately
 end
 
-#--- FIX ME - directories
+template 'my.ini' do
+  path "#{node['mysql']['windows']['bin_dir']}\\my.ini"
+  source 'my.ini.erb'
+  notifies :restart, "service[mysql]"
+end
 
-#----
 execute 'install mysql service' do
-  command %Q["#{node['mysql']['windows']['bin_dir']}\\mysqld.exe" --install "#{node['mysql']['server']['service_name']}"]
-  not_if { ::Win32::Service.exists?(node['mysql']['windows']['service_name']) }
-end
-
-#----
-template 'initial-my.cnf' do
-  path "#{node['mysql']['windows']['conf_dir']}/my.cnf"
-  source 'my.cnf.erb'
-  mode '0644'
-  notifies :reload, node['mysql']['windows']['service_name'], :delayed
-end
-
-#----
-
-windows_path node['mysql']['bin_dir'] do
-  action :add
-end
-
-windows_batch 'install mysql service' do
-  command "\"#{node['mysql']['bin_dir']}\\mysqld.exe\" --install #{node['mysql']['service_name']}"
-  not_if  { Win32::Service.exists?(node['mysql']['service_name']) }
-end
-
-#----
-
-src_dir = win_friendly_path("#{node['mysql']['basedir']}\\data")
-target_dir = win_friendly_path(node['mysql']['data_dir'])
-
-%w{mysql performance_schema}.each do |db|
-  execute 'mysql-move-db' do
-    command %Q[move "#{src_dir}\\#{db}" "#{target_dir}"]
-    action :run
-    not_if { File.exists?(node['mysql']['data_dir'] + '/mysql/user.frm') }
-  end
-end
-
-#----
-
-execute 'mysql-install-db' do
-  command 'mysql_install_db'
-  action :run
-  not_if { File.exists?(node['mysql']['data_dir'] + '/mysql/user.frm') }
+  command %Q["#{node['mysql']['windows']['bin_dir']}\\mysqld.exe" --install "#{node['mysql']['server']['service_name']}" --defaults-file="#{node['mysql']['windows']['bin_dir']}\\my.ini"]
+  not_if { ::Win32::Service.exists?(node['mysql']['server']['service_name']) }
 end
 
 service 'mysql' do
-  service_name node['mysql']['service_name']
-  provider     Chef::Provider::Service::Upstart if node['mysql']['use_upstart']
-  supports     :status => true, :restart => true, :reload => true
-  action       :enable
+  service_name node['mysql']['server']['service_name']
+  action       [:enable, :start]
 end
-
-template 'final-my.cnf' do
-  path "#{node['mysql']['conf_dir']}/my.cnf"
-  source 'my.cnf.erb'
-  mode '0644'
-  notifies :restart, 'service[mysql]', :immediately
-end
-
-#----
 
 execute 'assign-root-password' do
-  command %Q["#{node['mysql']['mysqladmin_bin']}" -u root password '#{node['mysql']['server_root_password']}']
+  command %Q["#{node['mysql']['windows']['mysqladmin_bin']}" -u root password #{node['mysql']['server_root_password']}]
   action :run
-  only_if %Q["#{node['mysql']['mysql_bin']}" -u root -e 'show databases;']
+  # only_if %Q["#{node['mysql']['windows']['mysql_bin']}" -u root -e 'show databases;'] # unreliable due to CHEF-4783; always returns 0 when run in Chef
+  not_if { node['mysql']['root_password_set'] }
+  notifies :run, "ruby_block[root-password-set]", :immediately
 end
 
-#----
-
-grants_path = node['mysql']['grants_path']
-
-begin
-  resources("template[#{grants_path}]")
-rescue
-  Chef::Log.info('Could not find previously defined grants.sql resource')
-  template grants_path do
-    source 'grants.sql.erb'
-    mode   '0600'
-    action :create
+ruby_block 'root-password-set' do
+  block do
+    node.set['mysql']['root_password_set'] = true
   end
-end
-
-#----
-windows_batch 'mysql-install-privileges' do
-  command "\"#{node['mysql']['mysql_bin']}\" -u root #{node['mysql']['server_root_password'].empty? ? '' : '-p' }\"#{node['mysql']['server_root_password']}\" < \"#{grants_path}\""
   action :nothing
-  subscribes :run, resources("template[#{grants_path}]"), :immediately
 end
 
-service 'mysql-start' do
-  service_name node['mysql']['server']['service_name']
-  action :start
+grants_path = node['mysql']['windows']['grants_path']
+
+template grants_path do
+  source 'grants.sql.erb'
+  action :create
+  notifies :run, "execute[mysql-install-privileges]", :immediately
+end
+
+execute 'mysql-install-privileges' do
+  command "\"#{node['mysql']['windows']['mysql_bin']}\" -u root #{node['mysql']['server_root_password'].empty? ? '' : '-p' }\"#{node['mysql']['server_root_password']}\" < \"#{grants_path}\""
+  action :nothing
 end

--- a/templates/windows/my.ini.erb
+++ b/templates/windows/my.ini.erb
@@ -56,10 +56,10 @@ max_allowed_packet        = <%= node['mysql']['tunable']['max_allowed_packet'] %
 
 #
 # Here you can see queries with especially long duration
-<%- if node['mysql']['version'].to_f >= 5.5 %>
-slow_query_log            = <%= node['mysql']['tunable']['slow_query_log'] %>
+<%- if node['mysql']['windows']['version'].to_f >= 5.5 %>
+slow_query_log            = <%= node['mysql']['server']['slow_query_log'] %>
 <% else %>
-log_slow_queries          = <%= node['mysql']['tunable']['slow_query_log'] %>
+log_slow_queries          = <%= node['mysql']['server']['slow_query_log'] %>
 <% end %>
 
 long_query_time           = <%= node['mysql']['tunable']['long_query_time'] %>


### PR DESCRIPTION
There were a number of items broken in the last refactor of this cookbook. This commit
rewrites the _server_windows recipe to account for a number of things:
- Running mysql commands as `not_if` guards is unreliable under Windows right now owing
  to [CHEF-4783](https://tickets.opscode.com/browse/CHEF-4783). Because the guard is run as a 32-bit CMD session rather than using
  the SysNative CMD, Windows will lie to you about the exit code and the guard always
  returns 0. As such I elected to use a node attribute to store whether the password
  is set, and use that as a guard.
- Upgrade to the latest version of MySQL 5.5 on the system.
- MySQL data properly belongs in \AppData -- that's what the interactive installer
  will do
- The my.cnf on Windows is called my.ini and it lives in the MySQL server's bin
  directory - again, this is what the "MySQL Instance Creation Wizard", run
  interactively, will do.
