### PR TITLE
[COOK-4240] Single quotes added to password grants

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -38,7 +38,7 @@ module Opscode
       def install_grants_cmd
         str = '/usr/bin/mysql'
         str << ' -u root '
-        node['mysql']['server_root_password'].empty? ? str << ' < /etc/mysql_grants.sql' : str << " -p#{node['mysql']['server_root_password']} < /etc/mysql_grants.sql"
+        node['mysql']['server_root_password'].empty? ? str << ' < /etc/mysql_grants.sql' : str << " -p\'#{node['mysql']['server_root_password']}\' < /etc/mysql_grants.sql"
       end
     end
   end


### PR DESCRIPTION
*\* install_grant_cmd failed when MySql password had special characters
*\* FIXED: single quotes added around MySql password

https://tickets.opscode.com/browse/COOK-4240
