### PR TITLE
use restart instead of reload for MySQL

### DIFF
--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -105,7 +105,7 @@ template '/etc/mysql/my.cnf' do
   group 'root'
   mode '0644'
   notifies :run, 'bash[move mysql data to datadir]', :immediately
-  notifies :reload, 'service[mysql]'
+  notifies :restart, 'service[mysql]'
 end
 
 # don't try this at home


### PR DESCRIPTION
Some system parameters are not dynamics and can't be updated using a reload (bind-address for example). To be able to update configuration without depending on the scope, just always restart MySQL
