### PR TITLE
COOK-4318 - use node.platform for amazon packages

### DIFF
--- a/attributes/server_rhel.rb
+++ b/attributes/server_rhel.rb
@@ -15,7 +15,10 @@ when 'rhel'
     default['mysql']['server']['packages'] = ['mysql-server']
     default['mysql']['server']['slow_query_log']       = 1
     default['mysql']['server']['slow_query_log_file']  = '/var/log/mysql/slow.log'
-  when 2013 # amazon linux
+  end
+
+  case node['platform']
+  when 'amazon'
     default['mysql']['server']['packages'] = ['mysql-server']
     default['mysql']['server']['slow_query_log']       = 1
     default['mysql']['server']['slow_query_log_file']  = '/var/log/mysql/slow.log'


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4318

The package list built for amazon platform is based on `platform_version`.
And it supports only version `2013.xx`, not `2012.xx`.

See https://github.com/opscode-cookbooks/mysql/blob/a68479e2ded438b0a441f3ffbd1de4c71395cb8d/attributes/server_rhel.rb#L18

Instead of using `platform_version` attribute, the `platform` attribute should be used.
