### PR TITLE
reload_action mysql

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -22,6 +22,7 @@
 default['mysql']['bind_address']               = node.attribute?('cloud') && node['cloud']['local_ipv4'] ? node['cloud']['local_ipv4'] : node['ipaddress']
 default['mysql']['port']                       = 3306
 default['mysql']['nice']                       = 0
+default['mysql']['server']['reload_action']    = 'reload'
 
 # eventually remove?  where is this used?
 if attribute?('ec2')

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -62,7 +62,7 @@ template '/etc/mysql/debian.cnf' do
   owner 'root'
   group 'root'
   mode '0600'
-  notifies :reload, 'service[mysql]'
+  notifies node['mysql']['server']['reload_action'], 'service[mysql]'
 end
 
 #----
@@ -105,7 +105,7 @@ template '/etc/mysql/my.cnf' do
   group 'root'
   mode '0644'
   notifies :run, 'bash[move mysql data to datadir]', :immediately
-  notifies :reload, 'service[mysql]'
+  notifies node['mysql']['server']['reload_action'], 'service[mysql]'
 end
 
 # don't try this at home


### PR DESCRIPTION
I'm setting lots of tunables, most of them can be applied after server `restart`, meaning `reload` action fails (as expected). I need an ability to use `restart` instead of `reload`

 Neither [pull request #155](https://github.com/opscode-cookbooks/mysql/pull/155), nor [pull request #140](https://github.com/opscode-cookbooks/mysql/pull/140) helped in my case.
They still schedule at least 1 `reload` action.

Added attribute:
    default['mysql']['server']['reload_action']    = 'reload' 

See also #155 and #140.
