### PR TITLE
Add default-storage-engine attribute

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -38,6 +38,7 @@ default['mysql']['allow_remote_root']               = false
 default['mysql']['remove_anonymous_users']          = false
 default['mysql']['remove_test_database']            = false
 default['mysql']['root_network_acl']                = nil
+default['mysql']['default-storage-engine']          = nil
 default['mysql']['tunable']['character-set-server'] = 'utf8'
 default['mysql']['tunable']['collation-server']     = 'utf8_general_ci'
 default['mysql']['tunable']['lower_case_table_names']  = nil

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -55,6 +55,10 @@ skip-external-locking
 skip-name-resolve
 <%- end %>
 
+<%- if node['mysql']['default-storage-engine'] %>
+default-storage-engine = <%= node['mysql']['default-storage-engine'] %> 
+<%- end %>
+
 # Charset and Collation
 character-set-server = <%= node['mysql']['tunable']['character-set-server'] %>
 collation-server     = <%= node['mysql']['tunable']['collation-server'] %>


### PR DESCRIPTION
Added attribute to override the default storage engine. Prior to MySQL
5.5 the default storage engine was MyISAM, in 5.5+ it is InnoDB. If the
default needs to be overriden for some reason, this new attribute will
allow that.
