### PR TITLE
[COOK-4421] Reinstate mysql service to start on boot

### DIFF
--- a/templates/default/init-mysql.conf.erb
+++ b/templates/default/init-mysql.conf.erb
@@ -3,7 +3,7 @@
 description     "MySQL Server"
 author          "Mario Limonciello <superm1@ubuntu.com>"
 
-#start on runlevel [2345]
+start on runlevel [2345]
 stop on starting rc RUNLEVEL=[016]
 
 respawn


### PR DESCRIPTION
Reinstate the `start on runlevel` directive in the init script for the mysql 
upstart service, commented out in opscode-cookbooks/mysql@3a1d9f9b65c1edae
as part of [COOK-4184]

Fixes https://tickets.opscode.com/browse/COOK-4421
