### PR TITLE
Force Upstart for Ubuntu 12.04 and later.

### DIFF
--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -124,7 +124,7 @@ bash 'move mysql data to datadir' do
 end
 
 service_provider = Chef::Provider::Service::Upstart if 'ubuntu' == node['platform'] &&
-  Chef::VersionConstraint.new('>= 13.10').include?(node['platform_version'])
+  Chef::VersionConstraint.new('>= 12.04').include?(node['platform_version'])
 
 service 'mysql' do
   provider service_provider


### PR DESCRIPTION
Without this, Chef creates sysv style symlinks which fail as the Ubuntu
package installs Upstart scripts.

Fixes https://tickets.opscode.com/browse/COOK-4435
