### PR TITLE
Relax openssl constraint

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -24,7 +24,7 @@ supports 'scientific'
 supports 'suse'
 supports 'windows'
 
-depends 'openssl',         '~> 1.1'
+depends 'openssl',         '>= 1.0'
 depends 'build-essential', '~> 1.4'
 
 # wat


### PR DESCRIPTION
This PR relaxes the openssl constraint.  It helps for those of us using the COOK-847 branch, which has yet to be merged into that cookbook: https://github.com/opscode-cookbooks/openssl/tree/COOK-847.  If you wouldn't mind relaxing this constraint, it would be appreciated.  :)
