### PR TITLE
Added workaround for pid file path for my.cnf template for ubuntu

### DIFF
--- a/libraries/provider_mysql_service_ubuntu.rb
+++ b/libraries/provider_mysql_service_ubuntu.rb
@@ -14,8 +14,8 @@ class Chef
           converge_by 'ubuntu pattern' do
             ##################
             prefix_dir = '/usr'
-            run_dir = '/var/run/mysql'
-            pid_file = '/var/run/mysql/mysql.pid'
+            run_dir = '/var/run/mysqld'
+            pid_file = '/var/run/mysqld/mysqld.pid'
             socket_file = '/var/run/mysqld/mysqld.sock'
             include_dir = '/etc/mysql/conf.d'
             ##################

--- a/templates/default/apparmor/usr.sbin.mysqld.erb
+++ b/templates/default/apparmor/usr.sbin.mysqld.erb
@@ -33,7 +33,7 @@
   <%= node['mysql']['data_dir'] %>/** rwk,
   /var/log/mysql/ r,
   /var/log/mysql/* rw,
-  /var/run/mysqld/mysqld.pid w,
+  /var/run/mysql/mysql.pid w,
   /var/run/mysqld/mysqld.sock w,
 
   /sys/devices/system/cpu/ r,


### PR DESCRIPTION
While using the cookbook on precise (64 or 32), the  mysql daemon can't start, because it can't create the pid file after reboot: /var/run/mysql does not exists after reboot, as much as it is symlinked with tmpfs.

I've found workaround for that, fix it more properly if needed.
Note also that standard apparmor template does not have /var/run/mysql path, which could be also a bug.
