### PR TITLE
Fixes typo in /var/run path

### DIFF
--- a/libraries/provider_mysql_service_ubuntu.rb
+++ b/libraries/provider_mysql_service_ubuntu.rb
@@ -15,7 +15,7 @@ class Chef
             ##################
             prefix_dir = '/usr'
             run_dir = '/var/run/mysql'
-            pid_file = '/var/run/mysql/mysql.pid'
+            pid_file = '/var/run/mysqld/mysql.pid'
             socket_file = '/var/run/mysqld/mysqld.sock'
             include_dir = '/etc/mysql/conf.d'
             ##################


### PR DESCRIPTION
Fixes typo. Changes `/var/run/mysql/mysql.pid` to `/var/run/mysqld/mysql.pid`.
See https://tickets.opscode.com/browse/COOK-4519
