### PR TITLE
COOK-4547: Shellescape server_root_password

### DIFF
--- a/libraries/provider_mysql_service_debian.rb
+++ b/libraries/provider_mysql_service_debian.rb
@@ -1,4 +1,5 @@
 require 'chef/provider/lwrp_base'
+require 'shellwords'
 
 class Chef
   class Provider
@@ -63,7 +64,7 @@ class Chef
             execute 'assign-root-password' do
               cmd = "#{prefix_dir}/bin/mysqladmin"
               cmd << ' -u root password '
-              cmd << node['mysql']['server_root_password']
+              cmd << Shellwords.escape(node['mysql']['server_root_password'])
               command cmd
               action :run
               only_if "#{prefix_dir}/bin/mysql -u root -e 'show databases;'"
@@ -82,7 +83,7 @@ class Chef
             if node['mysql']['server_root_password'].empty?
               pass_string = ''
             else
-              pass_string = "-p#{node['mysql']['server_root_password']}"
+              pass_string = '-p' + Shellwords.escape(node['mysql']['server_root_password'])
             end
 
             execute 'install-grants' do

--- a/libraries/provider_mysql_service_fedora.rb
+++ b/libraries/provider_mysql_service_fedora.rb
@@ -1,4 +1,5 @@
 require 'chef/provider/lwrp_base'
+require 'shellwords'
 
 class Chef
   class Provider
@@ -73,7 +74,7 @@ class Chef
             if node['mysql']['server_root_password'].empty?
               pass_string = ''
             else
-              pass_string = "-p#{node['mysql']['server_root_password']}"
+              pass_string = '-p' + Shellwords.escape(node['mysql']['server_root_password'])
             end
 
             execute 'install-grants' do
@@ -123,7 +124,7 @@ class Chef
             execute 'assign-root-password' do
               cmd = "#{prefix_dir}/bin/mysqladmin"
               cmd << ' -u root password '
-              cmd << node['mysql']['server_root_password']
+              cmd << Shellwords.escape(node['mysql']['server_root_password'])
               command cmd
               action :run
               only_if "#{prefix_dir}/bin/mysql -u root -e 'show databases;'"

--- a/libraries/provider_mysql_service_omnios.rb
+++ b/libraries/provider_mysql_service_omnios.rb
@@ -1,4 +1,5 @@
 require 'chef/provider/lwrp_base'
+require 'shellwords'
 
 include Opscode::Mysql::Helpers
 
@@ -171,7 +172,7 @@ class Chef
             execute 'assign-root-password' do
               cmd = "#{prefix_dir}/bin/mysqladmin"
               cmd << ' -u root password '
-              cmd << node['mysql']['server_root_password']
+              cmd << Shellwords.escape(node['mysql']['server_root_password'])
               command cmd
               action :run
               only_if "#{prefix_dir}/bin/mysql -u root -e 'show databases;'"
@@ -190,7 +191,7 @@ class Chef
             if node['mysql']['server_root_password'].empty?
               pass_string = ''
             else
-              pass_string = "-p#{node['mysql']['server_root_password']}"
+              pass_string = '-p' + Shellwords.escape(node['mysql']['server_root_password'])
             end
 
             execute 'install-grants' do

--- a/libraries/provider_mysql_service_rhel.rb
+++ b/libraries/provider_mysql_service_rhel.rb
@@ -1,4 +1,5 @@
 require 'chef/provider/lwrp_base'
+require 'shellwords'
 require_relative 'helpers'
 
 extend Opscode::Mysql::Helpers
@@ -152,7 +153,7 @@ class Chef
             if node['mysql']['server_root_password'].empty?
               pass_string = ''
             else
-              pass_string = "-p#{node['mysql']['server_root_password']}"
+              pass_string = '-p' + Shellwords.escape(node['mysql']['server_root_password'])
             end
 
             execute 'install-grants' do
@@ -202,7 +203,7 @@ class Chef
             execute 'assign-root-password' do
               cmd = "#{prefix_dir}/bin/mysqladmin"
               cmd << ' -u root password '
-              cmd << node['mysql']['server_root_password']
+              cmd << Shellwords.escape(node['mysql']['server_root_password'])
               command cmd
               action :run
               only_if "#{prefix_dir}/bin/mysql -u root -e 'show databases;'"

--- a/libraries/provider_mysql_service_smartos.rb
+++ b/libraries/provider_mysql_service_smartos.rb
@@ -1,4 +1,5 @@
 require 'chef/provider/lwrp_base'
+require 'shellwords'
 
 class Chef
   class Provider
@@ -157,7 +158,7 @@ class Chef
             execute 'assign-root-password' do
               cmd = "#{prefix_dir}/bin/mysqladmin"
               cmd << ' -u root password '
-              cmd << node['mysql']['server_root_password']
+              cmd << Shellwords.escape(node['mysql']['server_root_password'])
               command cmd
               action :run
               only_if "#{prefix_dir}/bin/mysql -u root -e 'show databases;'"
@@ -176,7 +177,7 @@ class Chef
             if node['mysql']['server_root_password'].empty?
               pass_string = ''
             else
-              pass_string = "-p#{node['mysql']['server_root_password']}"
+              pass_string = '-p' + Shellwords.escape(node['mysql']['server_root_password'])
             end
 
             execute 'install-grants' do

--- a/libraries/provider_mysql_service_ubuntu.rb
+++ b/libraries/provider_mysql_service_ubuntu.rb
@@ -1,4 +1,5 @@
 require 'chef/provider/lwrp_base'
+require 'shellwords'
 
 class Chef
   class Provider
@@ -63,7 +64,7 @@ class Chef
             execute 'assign-root-password' do
               cmd = "#{prefix_dir}/bin/mysqladmin"
               cmd << ' -u root password '
-              cmd << node['mysql']['server_root_password']
+              cmd << Shellwords.escape(node['mysql']['server_root_password'])
               command cmd
               action :run
               only_if "#{prefix_dir}/bin/mysql -u root -e 'show databases;'"
@@ -82,7 +83,7 @@ class Chef
             if node['mysql']['server_root_password'].empty?
               pass_string = ''
             else
-              pass_string = "-p#{node['mysql']['server_root_password']}"
+              pass_string = '-p' + Shellwords.escape(node['mysql']['server_root_password'])
             end
 
             execute 'install-grants' do


### PR DESCRIPTION
With this change, we can finally use spaces, exclamation marks, and "`rm -rf /`" as root_password.

[I did some smoke testing](https://github.com/srenatus/mysql/commit/01a747325b6c92a267e2c3cfb2a13505b5181592) in TK, some more testing might still be advisable.
