### PR TITLE
Allow users to install MySQL 5.5 and MySQL 5.6 on CentOS 6

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -79,6 +79,14 @@ module Opscode
               '5.1' => {
                 'package_name' => 'mysql-server',
                 'service_name' => 'mysqld'
+              },
+              '5.5' => {
+                'package_name' => 'mysql55-server',
+                'service_name' => 'mysqld'
+              },
+              '5.6' => {
+                'package_name' => 'mysql56u-server',
+                'service_name' => 'mysqld'
               }
             },
             '7' => {

--- a/libraries/provider_mysql_service_rhel.rb
+++ b/libraries/provider_mysql_service_rhel.rb
@@ -74,6 +74,26 @@ class Chef
               socket_file = '/var/lib/mysql/mysql.sock'
               package_name = 'mysql-server'
               service_name = 'mysqld'
+            when '5.5'
+              base_dir = ''
+              include_dir = "#{base_dir}/etc/mysql/conf.d"
+              prefix_dir = '/usr'
+              lc_messages_dir = nil
+              run_dir = '/var/run/mysqld'
+              pid_file = '/var/run/mysql/mysql.pid'
+              socket_file = '/var/lib/mysql/mysql.sock'
+              package_name = 'mysql55-server'
+              service_name = 'mysqld'
+            when '5.6'
+              base_dir = ''
+              include_dir = "#{base_dir}/etc/mysql/conf.d"
+              prefix_dir = '/usr'
+              lc_messages_dir = nil
+              run_dir = '/var/run/mysqld'
+              pid_file = '/var/run/mysql/mysql.pid'
+              socket_file = '/var/lib/mysql/mysql.sock'
+              package_name = 'mysql56u-server'
+              service_name = 'mysqld'
             end
           when '5'
             case new_resource.version

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,3 +16,5 @@ supports 'ubuntu'
 supports 'smartos'
 supports 'omnios'
 supports 'freebsd'
+
+depends 'yum-ius'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -17,6 +17,14 @@
 # limitations under the License.
 #
 
+case node['platform_version'].to_i.to_s
+when '6'
+  case node['mysql']['version']
+  when '5.5', '5.6'
+    include_recipe 'yum-ius'
+  end
+end
+
 mysql_service node['mysql']['service_name'] do
   port node['mysql']['port']
   data_dir node['mysql']['data_dir']
@@ -27,5 +35,6 @@ mysql_service node['mysql']['service_name'] do
   remove_anonymous_users node['mysql']['remove_anonymous_users']
   remove_test_database node['mysql']['remove_test_database']
   root_network_acl node['mysql']['root_network_acl']
+  version node['mysql']['version']
   action :create
 end


### PR DESCRIPTION
This allows users to specify a version of MySQL to install and allows CentOS 6 users to choose to install MySQL 5.5 or MySQL 5.6.
