### PR TITLE
appease apparmor 

### DIFF
--- a/templates/default/apparmor/usr.sbin.mysqld.erb
+++ b/templates/default/apparmor/usr.sbin.mysqld.erb
@@ -30,6 +30,7 @@
   /var/log/mysql.log rw,
   /var/log/mysql.err rw,
   /var/lib/mysql/ r,
+  <%= node['mysql']['data_dir'] %>/ r,
   <%= node['mysql']['data_dir'] %>/** rwk,
   /var/log/mysql/ r,
   /var/log/mysql/* rw,


### PR DESCRIPTION
get rid of following errors from /var/log/syslog on ubuntu (14.04 ?) 
Aug 20 12:11:41XXX kernel: [44551.172402] type=1400 audit(1408551101.021:100): apparmor="ALLOWED" operation="open" profile="/usr/sbin/mysqld" name="/mysql/data/dir/" pid=14432 comm="mysqld" requested_mask="r" denied_mask="r" fsuid=105 ouid=105
