### PR TITLE
fix debian pass_string

### DIFF
--- a/libraries/helpers_debian.rb
+++ b/libraries/helpers_debian.rb
@@ -25,10 +25,10 @@ module MysqlCookbook
         if new_resource.parsed_server_root_password.empty?
           pass_string = ''
         else
-          pass_string = '-p' + Shellwords.escape(new_resource.parsed_server_root_password)
+          pass_string = '-p ' + Shellwords.escape(new_resource.parsed_server_root_password)
         end
 
-        pass_string = '-p' + ::File.open('/etc/.mysql_root').read.chomp if ::File.exist?('/etc/.mysql_root')
+        pass_string = '-p ' + ::File.open('/etc/.mysql_root').read.chomp if ::File.exist?('/etc/.mysql_root')
         pass_string
       end
 


### PR DESCRIPTION
I've got this on Ubuntu 12.04 x64 during installation the cookbook

```
STDOUT: 
STDERR: ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)
---- End output of /usr/bin/mysql -u root -pilikerandompasswords < /etc/mysql_grants.sql ----
Ran /usr/bin/mysql -u root -pilikerandompasswords < /etc/mysql_grants.sql returned 1
[2014-08-29T15:03:08-04:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
ERROR: RuntimeError: chef-solo failed. See output above.
```

I use `roles` for installation. My json file is available here: https://gist.github.com/itsNikolay/863e0268a52627e8add3

After this fix the cookbook passed to green.
