### PR TITLE
Quote passwords in debian.cnf.erb

### DIFF
--- a/templates/default/debian/debian.cnf.erb
+++ b/templates/default/debian/debian.cnf.erb
@@ -1,12 +1,12 @@
 [client]
 host     = localhost
 user     = debian-sys-maint
-password = <%= @config.server_debian_password %>
+password = "<%= @config.server_debian_password %>"
 socket   = /var/run/mysqld/mysqld.sock
 
 [mysql_upgrade]
 host     = localhost
 user     = debian-sys-maint
-password = <%= @config.server_debian_password %>
+password = "<%= @config.server_debian_password %>"
 socket   = /var/run/mysqld/mysqld.sock
 basedir  = /usr


### PR DESCRIPTION
Passwords should be quoted to avoid problems if they include characters
with special meaning eg # which is otherwise interpreted as being the 
beginning of a comment.

Otherwise the debian-sys-maint user will not be able to connect.
