### PR TITLE
Fix compatibility problem with Chef Client < 11.14.0 

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -9,7 +9,7 @@ module Opscode
       end
 
       def sensitive_supported?
-        chef_version = Chef::VersionConstraint.new(">= 11.14.0")
+        chef_version = Chef::VersionConstraint.new('>= 11.14.0')
         chef_version.include?(Chef::VERSION)
       end
 

--- a/libraries/provider_mysql_service_debian.rb
+++ b/libraries/provider_mysql_service_debian.rb
@@ -64,9 +64,7 @@ class Chef
           end
 
           execute 'assign-root-password' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysqladmin"
             cmd << ' -u root password '
             cmd << Shellwords.escape(new_resource.parsed_server_root_password)
@@ -76,9 +74,7 @@ class Chef
           end
 
           template '/etc/mysql_grants.sql' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cookbook 'mysql'
             source 'grants/grants.sql.erb'
             owner 'root'
@@ -90,9 +86,7 @@ class Chef
           end
 
           execute 'install-grants' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysql"
             cmd << ' -u root '
             cmd << "#{pass_string} < /etc/mysql_grants.sql"
@@ -171,9 +165,7 @@ class Chef
           end
 
           execute 'create root marker' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = '/bin/echo'
             cmd << " '#{Shellwords.escape(new_resource.parsed_server_root_password)}'"
             cmd << ' > /etc/.mysql_root'

--- a/libraries/provider_mysql_service_fedora.rb
+++ b/libraries/provider_mysql_service_fedora.rb
@@ -63,9 +63,7 @@ class Chef
           end
 
           template '/etc/mysql_grants.sql' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cookbook 'mysql'
             source 'grants/grants.sql.erb'
             owner 'root'
@@ -77,9 +75,7 @@ class Chef
           end
 
           execute 'install-grants' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysql"
             cmd << ' -u root '
             cmd << "#{pass_string} < /etc/mysql_grants.sql"
@@ -125,9 +121,7 @@ class Chef
           end
 
           execute 'assign-root-password' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysqladmin"
             cmd << ' -u root password '
             cmd << Shellwords.escape(new_resource.parsed_server_root_password)
@@ -137,9 +131,7 @@ class Chef
           end
 
           execute 'create root marker' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = '/bin/echo'
             cmd << " '#{Shellwords.escape(new_resource.parsed_server_root_password)}'"
             cmd << ' > /etc/.mysql_root'

--- a/libraries/provider_mysql_service_freebsd.rb
+++ b/libraries/provider_mysql_service_freebsd.rb
@@ -17,7 +17,7 @@ class Chef
 
         include MysqlCookbook::Helpers::FreeBSD
         include Opscode::Mysql::Helpers
-        
+
         action :create do
 
           unless sensitive_supported?
@@ -80,9 +80,7 @@ class Chef
           end
 
           execute 'assign-root-password' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysqladmin"
             cmd << ' -u root password '
             cmd << Shellwords.escape(new_resource.parsed_server_root_password)
@@ -92,9 +90,7 @@ class Chef
           end
 
           template '/etc/mysql_grants.sql' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cookbook 'mysql'
             source 'grants/grants.sql.erb'
             owner 'root'
@@ -106,9 +102,7 @@ class Chef
           end
 
           execute 'install-grants' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysql"
             cmd << ' -u root '
             cmd << "#{pass_string} < /etc/mysql_grants.sql"
@@ -120,9 +114,7 @@ class Chef
           end
 
           execute 'create root marker' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = '/bin/echo'
             cmd << " '#{Shellwords.escape(new_resource.parsed_server_root_password)}'"
             cmd << ' > /etc/.mysql_root'

--- a/libraries/provider_mysql_service_omnios.rb
+++ b/libraries/provider_mysql_service_omnios.rb
@@ -161,9 +161,7 @@ class Chef
           end
 
           execute 'assign-root-password' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysqladmin"
             cmd << ' -u root password '
             cmd << Shellwords.escape(new_resource.parsed_server_root_password)
@@ -173,9 +171,7 @@ class Chef
           end
 
           template '/etc/mysql_grants.sql' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cookbook 'mysql'
             source 'grants/grants.sql.erb'
             owner 'root'
@@ -187,9 +183,7 @@ class Chef
           end
 
           execute 'install-grants' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysql"
             cmd << ' -u root '
             cmd << "#{pass_string} < /etc/mysql_grants.sql"
@@ -201,9 +195,7 @@ class Chef
           end
 
           execute 'create root marker' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = '/bin/echo'
             cmd << " '#{Shellwords.escape(new_resource.parsed_server_root_password)}'"
             cmd << ' > /etc/.mysql_root'

--- a/libraries/provider_mysql_service_rhel.rb
+++ b/libraries/provider_mysql_service_rhel.rb
@@ -77,9 +77,7 @@ class Chef
           end
 
           template '/etc/mysql_grants.sql' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cookbook 'mysql'
             source 'grants/grants.sql.erb'
             owner 'root'
@@ -91,9 +89,7 @@ class Chef
           end
 
           execute 'install-grants' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysql"
             cmd << ' -u root '
             cmd << "#{pass_string} < /etc/mysql_grants.sql"
@@ -139,9 +135,7 @@ class Chef
           end
 
           execute 'assign-root-password' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysqladmin"
             cmd << ' -u root password '
             cmd << Shellwords.escape(new_resource.parsed_server_root_password)
@@ -151,9 +145,7 @@ class Chef
           end
 
           execute 'create root marker' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = '/bin/echo'
             cmd << " '#{Shellwords.escape(new_resource.parsed_server_root_password)}'"
             cmd << ' > /etc/.mysql_root'

--- a/libraries/provider_mysql_service_smartos.rb
+++ b/libraries/provider_mysql_service_smartos.rb
@@ -158,9 +158,7 @@ class Chef
           end
 
           execute 'assign-root-password' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysqladmin"
             cmd << ' -u root password '
             cmd << Shellwords.escape(new_resource.parsed_server_root_password)
@@ -170,9 +168,7 @@ class Chef
           end
 
           template "#{prefix_dir}/etc/mysql_grants.sql" do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cookbook 'mysql'
             source 'grants/grants.sql.erb'
             owner 'root'
@@ -184,9 +180,7 @@ class Chef
           end
 
           execute 'install-grants' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysql"
             cmd << ' -u root '
             cmd << "#{pass_string} < #{prefix_dir}/etc/mysql_grants.sql"
@@ -196,9 +190,7 @@ class Chef
           end
 
           execute 'create root marker' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = '/bin/echo'
             cmd << " '#{Shellwords.escape(new_resource.parsed_server_root_password)}'"
             cmd << " > #{prefix_dir}/etc/.mysql_root"

--- a/libraries/provider_mysql_service_suse.rb
+++ b/libraries/provider_mysql_service_suse.rb
@@ -22,7 +22,7 @@ class Chef
           unless sensitive_supported?
             Chef::Log.debug("Sensitive attribute disabled, chef-client version #{Chef::VERSION} is lower than 11.14.0")
           end
-          
+
           package 'mysql' do
             action :install
           end
@@ -105,9 +105,7 @@ class Chef
           end
 
           template '/etc/mysql_grants.sql' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cookbook 'mysql'
             source 'grants/grants.sql.erb'
             owner 'root'
@@ -119,9 +117,7 @@ class Chef
           end
 
           execute 'install-grants' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = '/usr/bin/mysql'
             cmd << ' -u root '
             cmd << "#{pass_string} < /etc/mysql_grants.sql"
@@ -143,9 +139,7 @@ class Chef
           end
 
           execute 'assign-root-password' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = '/usr/bin/mysqladmin'
             cmd << ' -u root password '
             cmd << Shellwords.escape(new_resource.parsed_server_root_password)
@@ -155,9 +149,7 @@ class Chef
           end
 
           execute 'create root marker' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = '/bin/echo'
             cmd << " '#{Shellwords.escape(new_resource.parsed_server_root_password)}'"
             cmd << ' > /etc/.mysql_root'

--- a/libraries/provider_mysql_service_ubuntu.rb
+++ b/libraries/provider_mysql_service_ubuntu.rb
@@ -65,9 +65,7 @@ class Chef
           end
 
           execute 'assign-root-password' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysqladmin"
             cmd << ' -u root password '
             cmd << Shellwords.escape(new_resource.parsed_server_root_password)
@@ -77,9 +75,7 @@ class Chef
           end
 
           template '/etc/mysql_grants.sql' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cookbook 'mysql'
             source 'grants/grants.sql.erb'
             owner 'root'
@@ -91,9 +87,7 @@ class Chef
           end
 
           execute 'install-grants' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = "#{prefix_dir}/bin/mysql"
             cmd << ' -u root '
             cmd << "#{pass_string} < /etc/mysql_grants.sql"
@@ -196,9 +190,7 @@ class Chef
           end
 
           execute 'create root marker' do
-            if sensitive_supported?
-              sensitive true
-            end
+            sensitive true if sensitive_supported?
             cmd = '/bin/echo'
             cmd << " '#{Shellwords.escape(new_resource.parsed_server_root_password)}'"
             cmd << ' > /etc/.mysql_root'


### PR DESCRIPTION
Hi,

I've added a helper method to check if Chef::VERSION is greater or equal than 11.14.0 (where sensitive where introduced). This should bring back the complete Chef 11 compatibility.

I've tested against Ubuntu 14.04, OpenSUSE 13.1 and CentOS 6.5.

What do you think?

Cheers,
Jan
