### PR TITLE
use Gem::Version instead of Chef::Version

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -9,8 +9,7 @@ module Opscode
       end
 
       def sensitive_supported?
-        chef_version = Chef::VersionConstraint.new('>= 11.14.0')
-        chef_version.include?(Chef::VERSION)
+        Gem::Version.new(Chef::VERSION) >= Gem::Version.new('11.14.0')
       end
 
       def keyname_for(platform, platform_family, platform_version)


### PR DESCRIPTION
The Chef::Version class is only for cookbook versions and only supports
x.y.z version numbers.  It cannot be used to compare chef rubygems
versions without completely breaking prereleases.

See:

https://github.com/opscode/chef/blob/cb978d59239e7fcfea48749334185caa7064b9ea/lib/chef/version.rb#L23-L30
