### PR TITLE
enable_utf8 should be boolean, not String.

### DIFF
--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -23,7 +23,7 @@ class Chef
       attribute :version, :kind_of => String, :default => nil
       attribute :package_version, :kind_of => String, :default => nil
       attribute :package_action, :kind_of => String, :default => nil
-      attribute :enable_utf8, :kind_of => String, :default => false
+      attribute :enable_utf8, :kind_of => [TrueClass, FalseClass], :default => false
     end
 
     include Opscode::Mysql::Helpers


### PR DESCRIPTION
It is used in an "if" statement later, as a boolean. For some reason it is required to be a String. Default value is false. I suspect this is a bug.
