### PR TITLE
Fixed mysql cookbook to work on Amazon Linux AMI 2014.09. 

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -106,7 +106,7 @@ module Opscode
                 'package_name' => 'mysql51-server'
               },
               '5.5' => {
-                'package_name' => 'mysql-community-server'
+                'package_name' => 'mysql-server'
               },
               '5.6' => {
                 'package_name' => 'mysql-community-server'

--- a/libraries/provider_mysql_service_rhel.rb
+++ b/libraries/provider_mysql_service_rhel.rb
@@ -23,7 +23,7 @@ class Chef
           end
 
           # we need to enable the yum-mysql-community repository to get packages
-          unless node['platform_version'].to_i == 5
+          unless node['platform_version'].to_i == 5 || node['platform'] == 'amazon'
             case new_resource.parsed_version
             when '5.5'
               recipe_eval do


### PR DESCRIPTION
Prior to the fix the server recipe was trying to use the mysql-community-server from the
yum-mysql-community repository when installing version 5.5 and this resulted
in package conflicts and a failed installation.
