### PR TITLE
Remove incompatible bind_address method from default example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Then, in a recipe:
 
 ```ruby
 mysql_service 'default' do
-  bind_address '0.0.0.0'
   port '3306'
   version '5.5'
   initial_root_password 'change me'
@@ -107,7 +106,6 @@ omitted when used in recipes designed to build containers.
 ```ruby
 mysql_service 'default' do
   version '5.7'
-  bind_address '0.0.0.0'
   port '3306'
   data_dir '/data'
   initial_root_password 'Ch4ng3me'


### PR DESCRIPTION
Remove incompatible bind_address method from default example that uses version 6.0.
