### PR TITLE
Allow instance with mysql name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ end
 
 The service name on the OS is `mysql-foo`. You can manually start and stop it with `service mysql-foo start` and `service mysql-foo stop`.
 
+If you use `default` as the name the service name will be `mysql` instead of `mysql-default`.
+
 The configuration file is at `/etc/mysql-foo/my.cnf`. It contains the minimum options to get the service running. It looks like this.
 
 ```

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -80,7 +80,11 @@ module MysqlCookbook
     end
 
     def mysql_name
-      "mysql-#{instance}"
+      if instance == 'default'
+        'mysql'
+      else
+        "mysql-#{instance}"
+      end
     end
 
     def default_socket_file

--- a/templates/default/systemd/mysqld.service.erb
+++ b/templates/default/systemd/mysqld.service.erb
@@ -8,7 +8,7 @@ Type=simple
 User=<%= @config.run_user %>
 Group=<%= @config.run_group %>
 ExecStart=<%= @mysqld_bin %> --defaults-file=<%= @etc_dir %>/my.cnf --basedir=<%= @base_dir %>
-ExecStartPost=/usr/libexec/mysql-<%= @config.instance %>-wait-ready $MAINPID
+ExecStartPost=/usr/libexec/<%= @config.mysql_name %>-wait-ready $MAINPID
 TimeoutSec=300
 PrivateTmp=true
 


### PR DESCRIPTION
Based on https://github.com/chef-cookbooks/mysql/pull/531 bij @mdarii.
Fixed the indentation and the if statement.

### Description

Allow for default mysql service named "mysql".

### Issues Resolved

Fixes #536

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
