### PR TITLE
Make sure yum recipes are run in travis matrix

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,24 +19,14 @@ verifier:
 
 platforms:
   - name: centos-6
-    run_list:
-      - recipe[selinux::disabled]
-      - recipe[mysql_test::yum_repo]
 
   - name: centos-7
-    run_list:
-      - recipe[selinux::disabled]
-      - recipe[mysql_test::yum_repo]
-
 
   - name: debian-8
   
   - name: debian-9
 
   - name: fedora-28
-    run_list:
-      - recipe[selinux::disabled]
-      - recipe[mysql_test::yum_repo]
 
   - name: opensuse-leap
     driver:
@@ -88,6 +78,36 @@ suites:
        version: '5.7'
     includes: <%= dists_with_57 %>
 
+  - name: installation_client_package-55-yum
+    run_list:
+    - recipe[selinux::disabled]
+    - recipe[mysql_test::yum_repo]
+    - recipe[mysql_test::installation_client]
+    attributes:
+      mysql:
+       version: '5.5'
+    includes: <%= dists_with_55 %>
+
+  - name: installation_client_package-56-yum
+    run_list:
+    - recipe[selinux::disabled]
+    - recipe[mysql_test::yum_repo]
+    - recipe[mysql_test::installation_client]
+    attributes:
+      mysql:
+       version: '5.6'
+    includes: <%= dists_with_56 %>
+
+  - name: installation_client_package-57-yum
+    run_list:
+    - recipe[selinux::disabled]
+    - recipe[mysql_test::yum_repo]
+    - recipe[mysql_test::installation_client]
+    attributes:
+      mysql:
+       version: '5.7'
+    includes: <%= dists_with_57 %>
+
   #
   # server smoke
   #
@@ -118,7 +138,39 @@ suites:
   - name: smoke57
     run_list:
     - recipe[mysql_test::smoke]
+    - recipe[selinux::disabled]
+    - recipe[mysql_test::yum_repo]
     attributes:
       mysql:
        version: '5.7'
     includes: <%= dists_with_57 %>
+
+  - name: smoke55-yum
+    run_list:
+    - recipe[selinux::disabled]
+    - recipe[mysql_test::yum_repo]
+    - recipe[mysql_test::smoke]
+    attributes:
+      mysql:
+       version: '5.5'
+    includes: <%= dists_with_55 %>
+
+  - name: smoke56-yum
+    run_list:
+    - recipe[selinux::disabled]
+    - recipe[mysql_test::yum_repo]
+    - recipe[mysql_test::smoke]
+    attributes:
+      mysql:
+       version: '5.6'
+    includes: <%= dists_with_56 %>
+
+  - name: smoke57-yum
+    run_list:
+    - recipe[selinux::disabled]
+    - recipe[mysql_test::yum_repo]
+    - recipe[mysql_test::smoke]
+    attributes:
+      mysql:
+       version: '5.7'
+    includes: <%= dists_with_57 %>    

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -113,7 +113,7 @@ suites:
   #
   - name: smoke51
     run_list:
-    - recipe[mysql_test::smoke]
+      - recipe[mysql_test::smoke]
     attributes:
       mysql:
        version: '5.1'
@@ -121,7 +121,7 @@ suites:
 
   - name: smoke55
     run_list:
-    - recipe[mysql_test::smoke]
+      - recipe[mysql_test::smoke]
     attributes:
       mysql:
        version: '5.5'
@@ -129,7 +129,7 @@ suites:
 
   - name: smoke56
     run_list:
-    - recipe[mysql_test::smoke]
+      - recipe[mysql_test::smoke]
     attributes:
       mysql:
        version: '5.6'
@@ -137,9 +137,9 @@ suites:
 
   - name: smoke57
     run_list:
-    - recipe[mysql_test::smoke]
-    - recipe[selinux::disabled]
-    - recipe[mysql_test::yum_repo]
+      - recipe[mysql_test::smoke]
+      - recipe[selinux::disabled]
+      - recipe[mysql_test::yum_repo]
     attributes:
       mysql:
        version: '5.7'
@@ -147,9 +147,9 @@ suites:
 
   - name: smoke55-yum
     run_list:
-    - recipe[selinux::disabled]
-    - recipe[mysql_test::yum_repo]
-    - recipe[mysql_test::smoke]
+      - recipe[selinux::disabled]
+      - recipe[mysql_test::yum_repo]
+      - recipe[mysql_test::smoke]
     attributes:
       mysql:
        version: '5.5'
@@ -157,9 +157,9 @@ suites:
 
   - name: smoke56-yum
     run_list:
-    - recipe[selinux::disabled]
-    - recipe[mysql_test::yum_repo]
-    - recipe[mysql_test::smoke]
+      - recipe[selinux::disabled]
+      - recipe[mysql_test::yum_repo]
+      - recipe[mysql_test::smoke]
     attributes:
       mysql:
        version: '5.6'
@@ -167,9 +167,9 @@ suites:
 
   - name: smoke57-yum
     run_list:
-    - recipe[selinux::disabled]
-    - recipe[mysql_test::yum_repo]
-    - recipe[mysql_test::smoke]
+      - recipe[selinux::disabled]
+      - recipe[mysql_test::yum_repo]
+      - recipe[mysql_test::smoke]
     attributes:
       mysql:
        version: '5.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,28 +22,28 @@ env:
   - KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
   matrix:
   - INSTANCE=smoke51-centos-6
-  - INSTANCE=smoke55-centos-6
-  - INSTANCE=smoke55-centos-7
+  - INSTANCE=smoke55-yum-centos-6
+  - INSTANCE=smoke55-yum-centos-7
   - INSTANCE=smoke55-debian-8
   - INSTANCE=smoke55-ubuntu-1404
-  - INSTANCE=smoke56-centos-6
-  - INSTANCE=smoke56-centos-7
+  - INSTANCE=smoke56-yum-centos-6
+  - INSTANCE=smoke56-yum-centos-7
   - INSTANCE=smoke56-ubuntu-1404
   - INSTANCE=smoke56-opensuse-leap
-  - INSTANCE=smoke57-centos-6
-  - INSTANCE=smoke57-centos-7
+  - INSTANCE=smoke57-yum-centos-6
+  - INSTANCE=smoke57-yum-centos-7
   - INSTANCE=smoke57-ubuntu-1604
   - INSTANCE=installation-client-package-51-centos-6
-  - INSTANCE=installation-client-package-55-centos-6
-  - INSTANCE=installation-client-package-55-centos-7
+  - INSTANCE=installation-client-package-55-yum-centos-6
+  - INSTANCE=installation-client-package-55-yum-centos-7
   - INSTANCE=installation-client-package-55-debian-8
   - INSTANCE=installation-client-package-55-ubuntu-1404
-  - INSTANCE=installation-client-package-56-centos-6
-  - INSTANCE=installation-client-package-56-centos-7
+  - INSTANCE=installation-client-package-56-yum-centos-6
+  - INSTANCE=installation-client-package-56-yum-centos-7
   - INSTANCE=installation-client-package-56-ubuntu-1404
   - INSTANCE=installation-client-package-56-opensuse-leap
-  - INSTANCE=installation-client-package-57-centos-6
-  - INSTANCE=installation-client-package-57-centos-7
+  - INSTANCE=installation-client-package-57-yum-centos-6
+  - INSTANCE=installation-client-package-57-yum-centos-7
   - INSTANCE=installation-client-package-57-ubuntu-1604
 
 before_script:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -89,7 +89,6 @@ module MysqlCookbook
 
     def default_client_package_name
       return ['mysql', 'mysql-devel'] if major_version == '5.1' && el6?
-      return ['mysql', 'mysql-devel'] if el7?
       return ['mysql55', 'mysql55-devel.x86_64'] if major_version == '5.5' && node['platform'] == 'amazon'
       return ['mysql56', 'mysql56-devel.x86_64'] if major_version == '5.6' && node['platform'] == 'amazon'
       return ['mysql-client-5.5', 'libmysqlclient-dev'] if major_version == '5.5' && node['platform_family'] == 'debian'


### PR DESCRIPTION
### Description

The Centos platform `run_list` recipes were ignored in the build. This caused errors like:
 >  No candidate version available for mysql-community-server

Seperate kitchen suites have been created with the correct run_lists.

### Issues Resolved

Centos build were failing on the CI

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
