### PR TITLE
mysql-community-* does not exist in EL7

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -93,6 +93,7 @@ module MysqlCookbook
 
     def default_client_package_name
       return ['mysql', 'mysql-devel'] if major_version == '5.1' && el6?
+      return ['mysql', 'mysql-devel'] if el7?
       return ['mysql55', 'mysql55-devel.x86_64'] if major_version == '5.5' && node['platform'] == 'amazon'
       return ['mysql56', 'mysql56-devel.x86_64'] if major_version == '5.6' && node['platform'] == 'amazon'
       return ['mysql-client-5.5', 'libmysqlclient-dev'] if major_version == '5.5' && node['platform_family'] == 'debian'


### PR DESCRIPTION
was submitted before but accidentally reverted by 7255d7954e7bf92926b904369aa5e85b7a955893

# Description

CentOS 7 does not have packages named mysql-community-* so, installation fails. 

# Issues Resolved

[List any existing issues this PR resolves]

# Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable

Signed-off-by: Suleyman Kutlu <skutlu@schubergphilis.com>