### PR TITLE
Rename test cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,5 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
-  cookbook 'selinux'
-  cookbook 'mysql_test', path: 'test/cookbooks/mysql_test'
+  cookbook 'test', path: 'test/cookbooks/test'
 end

--- a/test/cookbooks/mysql_test/metadata.rb
+++ b/test/cookbooks/mysql_test/metadata.rb
@@ -1,4 +1,4 @@
-name 'mysql_test'
+name 'test'
 version '0.0.1'
 
 depends 'mysql'


### PR DESCRIPTION
- Renames test cookbook from mysql_test to test
- Removes the selinux dependency from the Berks config
