### PR TITLE
Add mysql57 support for Amazon Linux AMI

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -107,6 +107,7 @@ module MysqlCookbook
       return ['mysql', 'mysql-devel'] if el7?
       return ['mysql55', 'mysql55-devel.x86_64'] if major_version == '5.5' && node['platform'] == 'amazon'
       return ['mysql56', 'mysql56-devel.x86_64'] if major_version == '5.6' && node['platform'] == 'amazon'
+      return ['mysql57', 'mysql57-devel.x86_64'] if major_version == '5.7' && node['platform'] == 'amazon'
       return ['mysql-client-5.5', 'libmysqlclient-dev'] if major_version == '5.5' && node['platform_family'] == 'debian'
       return ['mysql-client-5.6', 'libmysqlclient-dev'] if major_version == '5.6' && node['platform_family'] == 'debian'
       return ['mysql-client-5.7', 'libmysqlclient-dev'] if major_version == '5.7' && node['platform_family'] == 'debian'
@@ -118,6 +119,7 @@ module MysqlCookbook
       return 'mysql-server' if major_version == '5.1' && el6?
       return 'mysql55-server' if major_version == '5.5' && node['platform'] == 'amazon'
       return 'mysql56-server' if major_version == '5.6' && node['platform'] == 'amazon'
+      return 'mysql57-server' if major_version == '5.7' && node['platform'] == 'amazon'
       return 'mysql-server-5.5' if major_version == '5.5' && node['platform_family'] == 'debian'
       return 'mysql-server-5.6' if major_version == '5.6' && node['platform_family'] == 'debian'
       return 'mysql-server-5.7' if major_version == '5.7' && node['platform_family'] == 'debian'


### PR DESCRIPTION
## Description

Add support for mysql57 on Amazon Linux AMI

### Issues Resolved

Support for installing mysql 5.7 server and client on Amazon Linux AMI

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/mysql/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
