### PR TITLE
Update 57 pw init

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,9 +1,10 @@
 <%
-yum_dists_with_56 = %w(centos-6 centos-7 fedora-28 amazon-linux)
+yum_dists_with_56 = %w(centos-6 centos-7 amazon-linux)
 suse_dists_with_56 = %w(opensuse-leap)
 apt_dists_with_56 = %w(ubuntu-14.04)
 yum_dists_with_57 = %w(centos-6 centos-7 fedora-28 fedora-latest)
 apt_dists_with_57 = %w(ubuntu-16.04 ubuntu-18.04)
+yum_dists_with_80 = %w(centos-6 centos-7 fedora-28 fedora-latest)
 %>
 ---
 driver:
@@ -82,6 +83,17 @@ suites:
        version: '5.7'
     includes: <%= yum_dists_with_57 %>
 
+  - name: installation_client_package-80-yum
+    run_list:
+    - recipe[selinux::disabled]
+    - recipe[test::yum_repo]
+    - recipe[test::installation_client]
+    attributes:
+      mysql:
+       version: '8.0'
+    includes: <%= yum_dists_with_80 %>
+
+
   #
   # server smoke
   #
@@ -130,3 +142,13 @@ suites:
       mysql:
        version: '5.7'
     includes: <%= yum_dists_with_57 %>
+
+  - name: smoke80-yum
+    run_list:
+      - recipe[selinux::disabled]
+      - recipe[test::yum_repo]
+      - recipe[test::smoke]
+    attributes:
+      mysql:
+       version: '8.0'
+    includes: <%= yum_dists_with_80 %>

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -199,13 +199,15 @@ module MysqlCookbook
       # Note: shell-escaping passwords in a SQL file may cause corruption - eg
       # mysql will read \& as &, but \% as \%. Just escape bare-minimum \ and '
       sql_escaped_password = root_password.gsub('\\') { '\\\\' }.gsub("'") { '\\\'' }
+      cmd = "UPDATE mysql.user SET #{password_column_name}=PASSWORD('#{sql_escaped_password}')#{password_expired} WHERE user = 'root';"
+      cmd = "ALTER USER 'root'@'localhost' IDENTIFIED BY '#{sql_escaped_password}';" if v57plus
 
       <<-EOS
         set -e
         rm -rf /tmp/#{mysql_name}
         mkdir /tmp/#{mysql_name}
         cat > /tmp/#{mysql_name}/my.sql <<-'EOSQL'
-UPDATE mysql.user SET #{password_column_name}=PASSWORD('#{sql_escaped_password}')#{password_expired} WHERE user = 'root';
+#{cmd}
 DELETE FROM mysql.user WHERE USER LIKE '';
 DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
 FLUSH PRIVILEGES;

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -175,14 +175,12 @@ module MysqlCookbook
     end
 
     def v56plus
-      return false if version.split('.')[0].to_i < 5
-      return false if version.split('.')[1].to_i < 6
+      return false if Gem::Version.new(version) < Gem::Version.new('5.6')
       true
     end
 
     def v57plus
-      return false if version.split('.')[0].to_i < 5
-      return false if version.split('.')[1].to_i < 7
+      return false if Gem::Version.new(version) < Gem::Version.new('5.7')
       true
     end
 

--- a/test/cookbooks/test/libraries/helpers.rb
+++ b/test/cookbooks/test/libraries/helpers.rb
@@ -10,6 +10,7 @@ def start_slave_1(root_pass)
   query << " MASTER_USER='repl',"
   query << " MASTER_PASSWORD='REPLICAAATE',"
   query << ' MASTER_PORT=3306,'
+  query << ' GET_MASTER_PUBLIC_KEY=1,' if Gem::Version.new(node['mysql']['version']) >= Gem::Version.new('8.0')
   query << " MASTER_LOG_POS=#{::File.open('/root/position').read.chomp};"
   query << ' START SLAVE;'
   shell_out!("echo \"#{query}\" | /usr/bin/mysql -u root -h 127.0.0.1 -P3307 -p#{Shellwords.escape(root_pass)}")
@@ -21,6 +22,7 @@ def start_slave_2(root_pass)
   query << " MASTER_USER='repl',"
   query << " MASTER_PASSWORD='REPLICAAATE',"
   query << ' MASTER_PORT=3306,'
+  query << ' GET_MASTER_PUBLIC_KEY=1,' if Gem::Version.new(node['mysql']['version']) >= Gem::Version.new('8.0')
   query << " MASTER_LOG_POS=#{::File.open('/root/position').read.chomp};"
   query << ' START SLAVE;'
   shell_out!("echo \"#{query}\" | /usr/bin/mysql -u root -h 127.0.0.1 -P3308 -p#{Shellwords.escape(root_pass)}")

--- a/test/cookbooks/test/recipes/smoke.rb
+++ b/test/cookbooks/test/recipes/smoke.rb
@@ -140,9 +140,9 @@ end
 # create databass on master
 bash 'create databass' do
   code <<-EOF
-  echo 'CREATE DATABASE databass;' | /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -p#{Shellwords.escape(root_pass_master)};
-  echo 'CREATE TABLE databass.table1 (name VARCHAR(20), rank VARCHAR(20));' | /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -p#{Shellwords.escape(root_pass_master)};
-  echo "INSERT INTO databass.table1 (name,rank) VALUES('captain','awesome');" | /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -p#{Shellwords.escape(root_pass_master)};
+  /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -p#{Shellwords.escape(root_pass_master)} -e 'CREATE DATABASE databass'
+  /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -p#{Shellwords.escape(root_pass_master)} -e 'CREATE TABLE databass.table1 (`name` VARCHAR(20), `rank` VARCHAR(20))'
+  /usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -p#{Shellwords.escape(root_pass_master)} -e 'INSERT INTO databass.table1 (`name`, `rank`) VALUES("captain","awesome")'
   EOF
   not_if "/usr/bin/mysql -u root -h 127.0.0.1 -P 3306 -p#{Shellwords.escape(root_pass_master)} -e 'show databases' | grep databass"
   action :run

--- a/test/cookbooks/test/recipes/smoke.rb
+++ b/test/cookbooks/test/recipes/smoke.rb
@@ -126,14 +126,14 @@ end
 # start replication on slave-1
 ruby_block 'start_slave_1' do
   block { start_slave_1(root_pass_slave) } # libraries/helpers.rb
-  not_if "/usr/bin/mysql -u root -h 127.0.0.1 -P 3307 -p#{Shellwords.escape(root_pass_slave)} -e 'SHOW SLAVE STATUS\G' | grep Slave_IO_State"
+  not_if "/usr/bin/mysql -u root -h 127.0.0.1 -P 3307 -p#{Shellwords.escape(root_pass_slave)} -e 'SHOW SLAVE STATUS\\G' | grep Slave_IO_State"
   action :run
 end
 
 # start replication on slave-2
 ruby_block 'start_slave_2' do
   block { start_slave_2(root_pass_slave) } # libraries/helpers.rb
-  not_if "/usr/bin/mysql -u root -h 127.0.0.1 -P 3308 -p#{Shellwords.escape(root_pass_slave)} -e 'SHOW SLAVE STATUS\G' | grep Slave_IO_State"
+  not_if "/usr/bin/mysql -u root -h 127.0.0.1 -P 3308 -p#{Shellwords.escape(root_pass_slave)} -e 'SHOW SLAVE STATUS\\G' | grep Slave_IO_State"
   action :run
 end
 

--- a/test/cookbooks/test/recipes/yum_repo.rb
+++ b/test/cookbooks/test/recipes/yum_repo.rb
@@ -6,5 +6,20 @@ unless node['mysql'].nil?
     include_recipe 'yum-mysql-community::mysql56'
   when '5.7'
     include_recipe 'yum-mysql-community::mysql57'
+  when '8.0'
+    if node['platform_family'] == 'rhel'
+      distro = 'el'
+    elsif node['platform_family'] == 'fedora'
+      distro = 'fc'
+    end
+    yum_repository 'mysql80-community' do
+      description 'MySQL 8.0 Community Server'
+      baseurl "http://repo.mysql.com/yum/mysql-8.0-community/#{distro}/$releasever/$basearch"
+      enabled true
+      failovermethod 'priority'
+      fastestmirror_enabled false
+      gpgcheck true
+      gpgkey 'http://repo.mysql.com/RPM-GPG-KEY-mysql'
+    end
   end
 end

--- a/test/integration/smoke56-suse/run_spec.rb
+++ b/test/integration/smoke56-suse/run_spec.rb
@@ -1,0 +1,13 @@
+# A fully secure / special-charactersy root password:
+# MyPa$$wordHas_"Special\'Chars%!
+
+require_relative '../spec_helper'
+
+# Extract version
+version = '5.6'
+# Client version
+check_mysql_client(version)
+# Server version
+check_mysql_server(version)
+# Master slave
+check_master_slave

--- a/test/integration/smoke56-yum/run_spec.rb
+++ b/test/integration/smoke56-yum/run_spec.rb
@@ -1,0 +1,13 @@
+# A fully secure / special-charactersy root password:
+# MyPa$$wordHas_"Special\'Chars%!
+
+require_relative '../spec_helper'
+
+# Extract version
+version = '5.6'
+# Client version
+check_mysql_client(version)
+# Server version
+check_mysql_server(version)
+# Master slave
+check_master_slave

--- a/test/integration/smoke57-yum/run_spec.rb
+++ b/test/integration/smoke57-yum/run_spec.rb
@@ -1,0 +1,13 @@
+# A fully secure / special-charactersy root password:
+# MyPa$$wordHas_"Special\'Chars%!
+
+require_relative '../spec_helper'
+
+# Extract version
+version = '5.7'
+# Client version
+check_mysql_client(version)
+# Server version
+check_mysql_server(version)
+# Master slave
+check_master_slave

--- a/test/integration/smoke80-yum/run_spec.rb
+++ b/test/integration/smoke80-yum/run_spec.rb
@@ -1,0 +1,13 @@
+# A fully secure / special-charactersy root password:
+# MyPa$$wordHas_"Special\'Chars%!
+
+require_relative '../spec_helper'
+
+# Extract version
+version = '8.0'
+# Client version
+check_mysql_client(version)
+# Server version
+check_mysql_server(version)
+# Master slave
+check_master_slave

--- a/test/integration/spec_helper.rb
+++ b/test/integration/spec_helper.rb
@@ -42,7 +42,8 @@ def check_mysql_client(version)
   # Version
   describe command("#{mysql_bin} --version") do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/Distrib #{version}/) }
+    its(:stdout) { should match(/Distrib #{version}/) } if Gem::Version.new(version) < Gem::Version.new('8.0')
+    its(:stdout) { should match(/Ver #{version}/) } if Gem::Version.new(version) >= Gem::Version.new('8.0')
     its(:stderr) { should eq '' }
   end
 


### PR DESCRIPTION
## Description

* Adds and updates tests for 8.0 yum distros, I looked at adding 8.0 debian, but 8.0 was installing `mysql-systemd-start` script under `/usr/share/mysql/8.0` and didn't want to include too many changes here. 
* Modifies `v56plus` and `v57plus` methods to use `Gem::Version`
* Modify the `init_records_script` to set the root password using `ALTER USER` for 5.7+, from https://github.com/sous-chefs/mysql/pull/518 and the issue linked below. 

### Issues Resolved

Fixes https://github.com/sous-chefs/mysql/issues/410
closes #518 
### Check List
- [x] All tests pass. See https://github.com/sous-chefs/mysql/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable - 

Couple questions:

Should I update the README with which platforms have been tested with Test Kitchen? And not sure if I should add a DCO to any commits (maybe the vplus methods?) since the init_records_script modification was authored by someone else. Thanks!
