### PR TITLE
Ignore .github as a directory

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -74,7 +74,7 @@ Rakefile
 */.bzr/*
 */.hg/*
 */.svn/*
-.github
+.github/*
 
 # Berkshelf #
 #############


### PR DESCRIPTION
## Description

The .github directory should be no longer ignored by newer versions of chef.

### Issues Resolved

After migrating to chef 14 the .github directory was no longer ignored.