### PR TITLE
Correct default package for el6/5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Set default packages for el6/5.6 to mysql mysql-devel mysql-server
 - migration to actions
 - Ability to include "none" as an installation method in mysql_service
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -104,6 +104,7 @@ module MysqlCookbook
 
     def default_client_package_name
       return %w(mysql mysql-devel) if major_version == '5.1' && el6?
+      return %w(mysql mysql-devel) if major_version == '5.6' && el6?
       return %w(mysql mysql-devel) if el7?
       return ['mysql55', 'mysql55-devel.x86_64'] if major_version == '5.5' && node['platform'] == 'amazon'
       return ['mysql56', 'mysql56-devel.x86_64'] if major_version == '5.6' && node['platform'] == 'amazon'
@@ -117,6 +118,7 @@ module MysqlCookbook
 
     def default_server_package_name
       return 'mysql-server' if major_version == '5.1' && el6?
+      return 'mysql-server' if major_version == '5.6' && el6?
       return 'mysql55-server' if major_version == '5.5' && node['platform'] == 'amazon'
       return 'mysql56-server' if major_version == '5.6' && node['platform'] == 'amazon'
       return 'mysql57-server' if major_version == '5.7' && node['platform'] == 'amazon'


### PR DESCRIPTION
## Description

Sets correct packages for el6/5.6 (mysql mysql-devel mysql-server). default_major_version no longer returns 5.1 for el6? https://github.com/sous-chefs/mysql/commit/d53a05ff2a76bab260e105fd4846d6d4191f4772#diff-38a4aeddb4e620724d3b85362cb8b939R71