### PR TITLE
Add apparmor template for ubuntu 20.04

### DIFF
--- a/templates/default/apparmor/ubuntu-20.04/usr.sbin.mysqld.erb
+++ b/templates/default/apparmor/ubuntu-20.04/usr.sbin.mysqld.erb
@@ -1,0 +1,68 @@
+# vim:syntax=apparmor
+# Last Modified: Tue Feb 09 15:28:30 2016
+#include <tunables/global>
+
+/usr/sbin/mysqld {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/user-tmp>
+  #include <abstractions/mysql>
+  #include <abstractions/winbind>
+
+# Allow system resource access
+  /sys/devices/system/cpu/ r,
+  capability sys_resource,
+  capability dac_override,
+  capability setuid,
+  capability setgid,
+
+# Allow network access
+  network tcp,
+
+  /etc/hosts.allow r,
+  /etc/hosts.deny r,
+
+# Allow config access
+  /etc/mysql/** r,
+
+# Allow pid, socket, socket lock file access
+  /var/run/mysqld/mysqld.pid rw,
+  /var/run/mysqld/mysqld.sock rw,
+  /var/run/mysqld/mysqld.sock.lock rw,
+  /run/mysqld/mysqld.pid rw,
+  /run/mysqld/mysqld.sock rw,
+  /run/mysqld/mysqld.sock.lock rw,
+
+# Allow execution of server binary
+  /usr/sbin/mysqld mr,
+  /usr/sbin/mysqld-debug mr,
+
+# Allow plugin access
+  /usr/lib/mysql/plugin/ r,
+  /usr/lib/mysql/plugin/*.so* mr,
+
+# Allow error msg and charset access
+  /usr/share/mysql/ r,
+  /usr/share/mysql/** r,
+
+# Allow data dir access
+  /var/lib/mysql/ r,
+  /var/lib/mysql/** rwk,
+
+# Allow data files dir access
+  /var/lib/mysql-files/ r,
+  /var/lib/mysql-files/** rwk,
+
+# Allow keyring dir access
+  /var/lib/mysql-keyring/ r,
+  /var/lib/mysql-keyring/** rwk,
+
+# Allow log file access
+  /var/log/mysql.err rw,
+  /var/log/mysql.log rw,
+  /var/log/mysql/ r,
+  /var/log/mysql/** rw,
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/usr.sbin.mysqld>
+}


### PR DESCRIPTION
Adds apparmor files for ubuntu 20.04. Simply copied the ubuntu 18.04 one.