### PR TITLE
Add dependency on apparmor cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add dependency on apparmor cookbook to fix #660
+
 ## 10.0.2 - *2021-02-25*
 
 - Update README.md to reflect dropping ubuntu 16.04 support and fixing the cookbook version in the usage section

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,8 @@ issues_url        'https://github.com/sous-chefs/mysql/issues'
 chef_version      '>= 12.7'
 version           '10.0.2'
 
+depends 'apparmor'
+
 %w(redhat centos scientific oracle).each do |el|
   supports el, '>= 7.0'
 end

--- a/test/cookbooks/test/recipes/smoke.rb
+++ b/test/cookbooks/test/recipes/smoke.rb
@@ -6,7 +6,7 @@ apt_update 'update'
 root_pass_master = 'MyPa$$word\Has_"Special\'Chars%!'
 root_pass_slave = 'An0th3r_Pa%%w0rd!'
 
-# TODO(ramereth): We should handle apparmor properly
+# We're not able to use apparmor with how this test is setup so disable it for now
 node.default['apparmor']['disable'] = true
 include_recipe 'apparmor'
 


### PR DESCRIPTION
This fixes #660.

We test for `node['apparmor']['disable']` in `libraries/mysql_service_base.rb` and fails on systems which doesn't include the apparmor cookbook. If we're depending on this attribute, we should also be depending on the cookbook which uses it, so this adds that dependency.

In addition, update the comment in the test for why we disable apparmor for our integration tests.

Signed-off-by: Lance Albertson <lance@osuosl.org>

## Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/mysql/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
