### PR TITLE
Fix db initialization status correctly on MySQL 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fix db initialization status correctly on MySQL 8.0
+
 ## 10.1.0 - *2021-03-11*
 
 - Add dependency on apparmor cookbook to fix #660

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -250,6 +250,14 @@ EOSQL
       mysql_install_db_cmd
     end
 
+    def db_initialized?
+      if v80plus
+        ::File.exist? "#{data_dir}/mysql.ibd"
+      else
+        ::File.exist? "#{data_dir}/mysql/user.frm"
+      end
+    end
+
     def mysql_install_db_bin
       return "#{base_dir}/scripts/mysql_install_db" if platform_family?('omnios')
       return "#{prefix_dir}/bin/mysql_install_db" if platform_family?('smartos')

--- a/libraries/mysql_service_base.rb
+++ b/libraries/mysql_service_base.rb
@@ -92,7 +92,7 @@ module MysqlCookbook
           code init_records_script
           umask '022'
           returns [0, 1, 2] # facepalm
-          not_if "/usr/bin/test -f #{new_resource.data_dir}/mysql/user.frm"
+          not_if { db_initialized? }
           action :run
         end
       end


### PR DESCRIPTION
This fixes #661.

On MySQL >= 8.0, it doesn't use MyASM by default anymore and thus we should be checking for a different file to see if the database has been properly initialized. Without this, this cookbook will try to initialize the database on every run causing obvious issues.

Signed-off-by: Lance Albertson <lance@osuosl.org>

## Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/mysql/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
