### PR TITLE
Fix ctrl_user always set to root for user resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fix ctrl\_user always set as root for mysql\_user resource
+
 ## 10.1.1 - *2021-03-11*
 
 - Fix db initialization status correctly on MySQL 8.0

--- a/resources/mysql_user.rb
+++ b/resources/mysql_user.rb
@@ -42,7 +42,6 @@ action :create do
       unless database_has_password_column
         create_sql << ' REQUIRE SSL' if new_resource.require_ssl
         create_sql << ' REQUIRE X509' if new_resource.require_x509
-        create_sql << ' WITH GRANT OPTION' if new_resource.grant_option
       end
       run_query create_sql
       update_user_password if new_resource.password

--- a/resources/mysql_user.rb
+++ b/resources/mysql_user.rb
@@ -267,8 +267,8 @@ action :grant do
       if database_has_password_column
         repair_sql << ' REQUIRE SSL' if new_resource.require_ssl
         repair_sql << ' REQUIRE X509' if new_resource.require_x509
-        repair_sql << ' WITH GRANT OPTION' if new_resource.grant_option
       end
+      repair_sql << ' WITH GRANT OPTION' if new_resource.grant_option
 
       redacted_sql = redact_password(repair_sql, new_resource.password)
       Chef::Log.debug("#{@new_resource}: granting with sql [#{redacted_sql}]")

--- a/resources/mysql_user.rb
+++ b/resources/mysql_user.rb
@@ -66,7 +66,7 @@ action_class do
 
   def run_query(query)
     socket = new_resource.ctrl_host == 'localhost' ? default_socket_file : nil
-    ctrl_hash = { host: new_resource.ctrl_host, port: new_resource.ctrl_port, username: new_resource.ctrl_user, password: new_resource.ctrl_password, socket: socket }
+    ctrl_hash = { host: new_resource.ctrl_host, port: new_resource.ctrl_port, user: new_resource.ctrl_user, password: new_resource.ctrl_password, socket: socket }
     Chef::Log.debug("#{@new_resource}: Performing query [#{query}]")
     execute_sql(query, nil, ctrl_hash)
   end

--- a/test/cookbooks/test/recipes/user_database.rb
+++ b/test/cookbooks/test/recipes/user_database.rb
@@ -178,11 +178,12 @@ mysql_user 'bunsen' do
   password 'burner'
   host 'localhost'
   ctrl_password root_pass
-  privileges [:super]
+  privileges [:all]
   grant_option true
   action [:create, :grant]
 end
 
+# try to create another user with non-default ctrl user
 mysql_user 'waldorf' do
   password 'InTheBalcony'
   database_name 'databass'

--- a/test/cookbooks/test/recipes/user_database.rb
+++ b/test/cookbooks/test/recipes/user_database.rb
@@ -173,6 +173,25 @@ mysql_user 'moozie' do
   action [:create, :grant]
 end
 
+# test non-default ctrl user
+mysql_user 'bunsen' do
+  password 'burner'
+  host 'localhost'
+  ctrl_password root_pass
+  privileges [:super]
+  grant_option true
+  action [:create, :grant]
+end
+
+mysql_user 'waldorf' do
+  password 'InTheBalcony'
+  database_name 'databass'
+  ctrl_user 'bunsen'
+  ctrl_password 'burner'
+  privileges [:select]
+  action [:create, :grant]
+end
+
 # all the grants exist ('Granting privs' should not show up), but the password is different
 # and should get updated
 mysql_user 'rizzo' do


### PR DESCRIPTION
## Description

Fixes error in the mysql_user resource and adds a smoke test to prevent it from being introduced again. Also, as a product of writing the test, fixes some issues with `WITH GRANT OPTION`.

### Issues Resolved

Fixes #664 

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/mysql/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
