### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- resolved cookstyle error: spec/mysql_client_installation_package_spec.rb:6:46 warning: `Chef/Deprecations/DeprecatedChefSpecPlatform`
+- resolved cookstyle error: spec/mysql_server_installation_package_spec.rb:6:46 warning: `Chef/Deprecations/DeprecatedChefSpecPlatform`
 ## 11.0.1 - *2022-01-08*
 
 - resolved cookstyle error: test/cookbooks/test/libraries/helpers.rb:14:31 convention: `Style/FileRead`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 - resolved cookstyle error: spec/mysql_client_installation_package_spec.rb:6:46 warning: `Chef/Deprecations/DeprecatedChefSpecPlatform`
 - resolved cookstyle error: spec/mysql_server_installation_package_spec.rb:6:46 warning: `Chef/Deprecations/DeprecatedChefSpecPlatform`
+- Stop specifying the Fedora version, so we default to latest
+
 ## 11.0.1 - *2022-01-08*
 
 - resolved cookstyle error: test/cookbooks/test/libraries/helpers.rb:14:31 convention: `Style/FileRead`

--- a/spec/mysql_client_installation_package_spec.rb
+++ b/spec/mysql_client_installation_package_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'test::installation_client' do
   let(:installation_client_package_centos_7) { ChefSpec::ServerRunner.new(platform: 'centos', version: '7') }
   let(:installation_client_package_centos_8) { ChefSpec::ServerRunner.new(platform: 'centos', version: '8') }
-  let(:installation_client_package_fedora) { ChefSpec::ServerRunner.new(platform: 'fedora', version: '31') }
+  let(:installation_client_package_fedora) { ChefSpec::ServerRunner.new(platform: 'fedora', version: '32') }
   let(:installation_client_package_ubuntu_1804) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04') }
 
   context 'using el7' do

--- a/spec/mysql_client_installation_package_spec.rb
+++ b/spec/mysql_client_installation_package_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'test::installation_client' do
   let(:installation_client_package_centos_7) { ChefSpec::ServerRunner.new(platform: 'centos', version: '7') }
   let(:installation_client_package_centos_8) { ChefSpec::ServerRunner.new(platform: 'centos', version: '8') }
-  let(:installation_client_package_fedora) { ChefSpec::ServerRunner.new(platform: 'fedora', version: '32') }
+  let(:installation_client_package_fedora) { ChefSpec::ServerRunner.new(platform: 'fedora') }
   let(:installation_client_package_ubuntu_1804) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04') }
 
   context 'using el7' do

--- a/spec/mysql_server_installation_package_spec.rb
+++ b/spec/mysql_server_installation_package_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'test::installation_server' do
   let(:installation_server_package_centos_7) { ChefSpec::ServerRunner.new(platform: 'centos', version: '7') }
   let(:installation_server_package_centos_8) { ChefSpec::ServerRunner.new(platform: 'centos', version: '8') }
-  let(:installation_server_package_fedora) { ChefSpec::ServerRunner.new(platform: 'fedora', version: '31') }
+  let(:installation_server_package_fedora) { ChefSpec::ServerRunner.new(platform: 'fedora', version: '32') }
   let(:installation_server_package_ubuntu_1804) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04') }
 
   context 'using el7' do

--- a/spec/mysql_server_installation_package_spec.rb
+++ b/spec/mysql_server_installation_package_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'test::installation_server' do
   let(:installation_server_package_centos_7) { ChefSpec::ServerRunner.new(platform: 'centos', version: '7') }
   let(:installation_server_package_centos_8) { ChefSpec::ServerRunner.new(platform: 'centos', version: '8') }
-  let(:installation_server_package_fedora) { ChefSpec::ServerRunner.new(platform: 'fedora', version: '32') }
+  let(:installation_server_package_fedora) { ChefSpec::ServerRunner.new(platform: 'fedora') }
   let(:installation_server_package_ubuntu_1804) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04') }
 
   context 'using el7' do


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.31.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with spec/mysql_client_installation_package_spec.rb

 - 6:46 warning: `Chef/Deprecations/DeprecatedChefSpecPlatform` - Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3 (https://docs.chef.io/workstation/cookstyle/chef_deprecations_deprecatedchefspecplatform)

### Issues found and resolved with spec/mysql_server_installation_package_spec.rb

 - 6:46 warning: `Chef/Deprecations/DeprecatedChefSpecPlatform` - Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3 (https://docs.chef.io/workstation/cookstyle/chef_deprecations_deprecatedchefspecplatform)