### PR TITLE
bugfix: Change db_initialized? function to check against database instead of files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-Fix #715: Update `db_initialized?` to be based on database connection instead of file existence
-
 ## 11.1.9 - *2024-12-09*
 
 ## 11.1.8 - *2024-11-18*
@@ -663,7 +661,7 @@ Adding Ubuntu 13.04 to Platforminfo
 - **[COOK-2966] - Address foodcritic failures'
 - **[COOK-4182] - Template parse failure in /etc/init/mysql.conf (data_dir)'
 - **[COOK-4198] - Added missing tunable'
-- **[COOK-4206] - create `root@127.0.0.1`, as well as `root@localhost`'
+- **[COOK-4206] - create root@127.0.0.1, as well as root@localhost'
 
 ## [4.0.20] - 2014-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+Fix #715: Update `db_initialized?` to be based on database connection instead of file existence
+
 ## 11.1.9 - *2024-12-09*
 
 ## 11.1.8 - *2024-11-18*
@@ -661,7 +663,7 @@ Adding Ubuntu 13.04 to Platforminfo
 - **[COOK-2966] - Address foodcritic failures'
 - **[COOK-4182] - Template parse failure in /etc/init/mysql.conf (data_dir)'
 - **[COOK-4198] - Added missing tunable'
-- **[COOK-4206] - create root@127.0.0.1, as well as root@localhost'
+- **[COOK-4206] - create `root@127.0.0.1`, as well as `root@localhost`'
 
 ## [4.0.20] - 2014-01-18
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -257,11 +257,21 @@ EOSQL
     end
 
     def db_initialized?
-      if v80plus
-        ::File.exist? "#{data_dir}/mysql.ibd"
-      else
-        ::File.exist? "#{data_dir}/mysql/user.frm"
-      end
+      cmd = shell_out("test \"#{db_initialized_check_cmd}\" -gt 0", user: 'root')
+      cmd.exitstatus == 0
+    end
+
+    def db_initialized_check_cmd
+      # If MySQL is running, mysqladmin ping will return 0 even with invalid credentials
+      # if MySQL is not running, mysqladmin will return 1 even with valid credentials
+      cmd = mysqladmin_bin
+      cmd << ' --user=UNKNOWN_MYSQL_USER'
+      cmd << ' ping > /dev/null 2>&1 &&'
+      cmd << " #{mysql_client_bin} #{defaults_file}"
+      cmd << ' --skip-column-names  --batch'
+      cmd << " --execute=\"SELECT count(*) FROM mysql.db WHERE db LIKE 'test%'\""
+      return "scl enable #{scl_name} \"#{cmd}\"" if scl_package?
+      cmd
     end
 
     def mysql_install_db_bin
@@ -277,6 +287,12 @@ EOSQL
       cmd << ' --explicit_defaults_for_timestamp' if v56plus && !v57plus
       return "scl enable #{scl_name} \"#{cmd}\"" if scl_package?
       cmd
+    end
+
+    def mysql_client_bin
+      return "#{prefix_dir}/bin/mysql" if platform_family?('smartos')
+      return 'mysql' if scl_package?
+      "#{prefix_dir}/usr/bin/mysql"
     end
 
     def mysqladmin_bin

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -256,14 +256,6 @@ EOSQL
       mysql_install_db_cmd
     end
 
-    def db_initialized?
-      if v80plus
-        ::File.exist? "#{data_dir}/mysql.ibd"
-      else
-        ::File.exist? "#{data_dir}/mysql/user.frm"
-      end
-    end
-
     def mysql_install_db_bin
       return "#{base_dir}/scripts/mysql_install_db" if platform_family?('omnios')
       return "#{prefix_dir}/bin/mysql_install_db" if platform_family?('smartos')

--- a/libraries/mysql_service_base.rb
+++ b/libraries/mysql_service_base.rb
@@ -91,8 +91,7 @@ module MysqlCookbook
         bash "#{new_resource.name} initial records" do
           code init_records_script
           umask '022'
-          returns [0, 1, 2] # facepalm
-          not_if { db_initialized? }
+          not_if { ::File.exist?("#{new_resource.pid_file}") }
           action :run
         end
       end

--- a/libraries/mysql_service_base.rb
+++ b/libraries/mysql_service_base.rb
@@ -91,6 +91,7 @@ module MysqlCookbook
         bash "#{new_resource.name} initial records" do
           code init_records_script
           umask '022'
+          returns [0, 1, 2] # facepalm
           not_if { ::File.exist?("#{new_resource.pid_file}") }
           action :run
         end


### PR DESCRIPTION
# Description

Updates `db_initialized?` so it verifies it can connect to MySQL and if so see if the `mysql.db` has been updated which will let the system know whether or not to run `initialize_database`

## Issues Resolved

https://github.com/sous-chefs/mysql/issues/715
possibly: https://github.com/sous-chefs/mysql/issues/681

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
